### PR TITLE
fix: fixed connection error when sending multiple commands

### DIFF
--- a/drivers/yeelights/device.js
+++ b/drivers/yeelights/device.js
@@ -264,13 +264,12 @@ class YeelightDevice extends Homey.Device {
   	} else {
       yeelights[id].socket.write(command + '\r\n');
 
-      if (yeelights[id].timeout === null) {
-        yeelights[id].timeout = setTimeout(() => {
-          if (yeelights[id].connected === true && yeelights[id].socket !== null) {
-            yeelights[id].socket.emit('error', new Error('Error sending command'));
-          }
-        }, 3000);
-      }
+      clearTimeout(yeelights[id].timeout);
+      yeelights[id].timeout = setTimeout(() => {
+        if (yeelights[id].connected === true && yeelights[id].socket !== null) {
+          yeelights[id].socket.emit('error', new Error('Error sending command'));
+        }
+      }, 3000);
     }
   }
 


### PR DESCRIPTION
When sending multiple commands it was very likely that the connection would be dropped. This is because the first commands sets a timeout of 3 seconds to check if the socket has cleared but subsequent commands also fill this socket value but do not reset the 3 second timout timer.