### PR TITLE
feat: added support for model 'ceiling1'

### DIFF
--- a/drivers/yeelights/driver.js
+++ b/drivers/yeelights/driver.js
@@ -8,7 +8,7 @@ const typeCapabilityMap = {
 	'color'    : [ 'onoff', 'dim', 'light_hue', 'light_saturation', 'light_temperature', 'light_mode' ],
   'stripe'   : [ 'onoff', 'dim', 'light_hue', 'light_saturation', 'light_temperature', 'light_mode' ],
   'bslamp'   : [ 'onoff', 'dim', 'light_hue', 'light_saturation', 'light_temperature', 'light_mode' ],
-  'ceiling'  : [ 'onoff', 'dim', 'light_temperature', 'light_mode' ],
+  'ceiling'  : [ 'onoff', 'dim', 'light_temperature', 'light_mode', 'night_mode' ],
   'ceiling4' : [ 'onoff', 'dim', 'light_hue', 'light_saturation', 'light_temperature', 'light_mode' ],
   'desklamp' : [ 'onoff', 'dim', 'light_temperature', 'light_mode' ]
 }
@@ -42,7 +42,11 @@ class YeelightDriver extends Homey.Driver {
             var name = Homey.__('yeelight_led_strip')+ ' (' + result[i].address + ')';
           } else if (result[i].model == 'bslamp') {
             var name = Homey.__('yeelight_bedside_lamp')+ ' (' + result[i].address + ')';
-          } else if (result[i].model == 'ceiling' || result[i].model == 'ceiling4') {
+          } else if (result[i].model.startsWith('ceiling')) {
+            if(result[i].model !== 'ceiling4') {
+              // Default the ceiling light to the default ceiling light.
+              result[i].model = 'ceiling';
+            }
             var name = Homey.__('yeelight_ceiling_light')+ ' (' + result[i].address + ')';
           } else if (result[i].model == 'desklamp') {
             var name = Homey.__('yeelight_desklamp')+ ' (' + result[i].address + ')';


### PR DESCRIPTION
My lamp has the model id 'ceiling1'. I expect this ceiling light to be the same as ceiling lights with model 'ceiling' so I added code to default all 'ceilingX' lights to 'ceiling' when it is not a model that has a different implementation (like 'ceiling4')