### PR TITLE
feat: added night_mode capability and flow card

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,6 +53,12 @@ class XiaomiMiioApp extends Homey.App {
         return Promise.resolve(customcommand);
       })
 
+    new Homey.FlowCardAction('yeelightNightMode')
+      .register()
+      .registerRunListener((args, state) => {
+        return args.device.triggerCapabilityListener('night_mode', args.value === 'true');
+      })
+
     // MI ROBOT: CONDITION AND ACTION FLOW CARDS
     new Homey.FlowCardAction('findVacuum')
       .register()

--- a/app.json
+++ b/app.json
@@ -38,6 +38,16 @@
 	"dependencies": {
 		"net": "*"
 	},
+	"capabilities": {
+		"night_mode": {
+			"type": "boolean",
+			"title": {
+				"en": "Night Mode"
+			},
+			"getable": true,
+			"setable": true
+		}
+	},
 	"drivers": [
     {
 			"id": "yeelights",
@@ -1067,6 +1077,52 @@
 						},
 						"filter": "driver_id=yeelights"
           }
+				]
+			},
+			{
+				"id": "yeelightNightMode",
+				"title": {
+					"en": "Toggle Night Mode",
+					"nl": "Schakel Nacht Modus"
+				},
+				"hint": {
+					"en": "Use this card to switch the light between night mode and normal mode",
+					"nl": "Gebruik deze actie om de lamp tussen nacht modus en gewone modus te schakelen"
+				},
+				"args": [
+					{
+						"name": "value",
+						"type": "dropdown",
+						"placeholder": {
+							"en": "Finish action",
+							"nl": "Afrondactie"
+						},
+						"values": [
+							{
+								"id": "false",
+								"label": {
+									"en": "Normal Mode",
+									"nl": "Normale Modus"
+								}
+							},
+							{
+								"id": "true",
+								"label": {
+									"en": "Night Mode",
+									"nl": "Nacht Modus"
+								}
+							}
+						]
+					},
+					{
+						"name": "device",
+						"type": "device",
+						"placeholder": {
+							"en": "Select Yeelight",
+							"nl": "Selecteer Yeelight"
+						},
+						"filter": "driver_id=yeelights&capabilities=night_mode"
+					}
 				]
 			},
       {

--- a/drivers/yeelights/device.js
+++ b/drivers/yeelights/device.js
@@ -13,6 +13,7 @@ class YeelightDevice extends Homey.Device {
     this.registerCapabilityListener('dim', this.onCapabilityDim.bind(this));
     this.registerMultipleCapabilityListener(['light_hue', 'light_saturation'], this.onCapabilityHueSaturation.bind(this), 500);
     this.registerCapabilityListener('light_temperature', this.onCapabilityLightTemperature.bind(this));
+    this.registerCapabilityListener('night_mode', this.onCapabilityNightMode.bind(this));
 
     let id = this.getData().id;
     yeelights[id] = {};
@@ -37,6 +38,15 @@ class YeelightDevice extends Homey.Device {
       this.sendCommand(this.getData().id, '{"id": 1, "method": "set_power", "params":["on", "smooth", 500]}');
     } else {
       this.sendCommand(this.getData().id, '{"id": 1, "method": "set_power", "params":["off", "smooth", 500]}');
+    }
+    callback(null, value);
+  }
+
+  onCapabilityNightMode(value, opts, callback) {
+    if (value) {
+      this.sendCommand(this.getData().id, '{"id": 1, "method": "set_power", "params":["on", "smooth", 500, 5]}');
+    } else {
+      this.sendCommand(this.getData().id, '{"id": 1, "method": "set_power", "params":["on", "smooth", 500, 1]}');
     }
     callback(null, value);
   }

--- a/drivers/yeelights/device.js
+++ b/drivers/yeelights/device.js
@@ -97,6 +97,10 @@ class YeelightDevice extends Homey.Device {
     }
     this.sendCommand(this.getData().id, '{"id":1,"method":"set_ct_abx","params":['+ color_temp +', "smooth", 500]}');
     callback(null, value);
+
+    if(this.hasCapability('night_mode')){
+      this.setCapabilityValue('night_mode', false);
+    }
   }
 
   // HELPER FUNCTIONS
@@ -267,6 +271,7 @@ class YeelightDevice extends Homey.Device {
 
   /* send commands to devices using their socket connection */
   sendCommand(id, command) {
+    console.log(command);
   	if (yeelights[id].connected === false && yeelights[id].socket !== null) {
       yeelights[id].socket.emit('error', new Error('Connection to device broken'));
     } else if (yeelights[id].socket === null) {


### PR DESCRIPTION
Since the Yeelight ceiling light has a night mode using the 'mode' argument of the set_power command (see https://www.yeelight.com/download/Yeelight_Inter-Operation_Spec.pdf) I added a flow card for 'ceiling' lights to switch between Night mode and CT mode.