### PR TITLE
Feat: auto toggle night mode

### DIFF
--- a/drivers/yeelights/device.js
+++ b/drivers/yeelights/device.js
@@ -41,18 +41,57 @@ class YeelightDevice extends Homey.Device {
     callback(null, value);
   }
 
-  onCapabilityDim(value, opts, callback) {
-    if(value == 0) {
-      var brightness = 1;
-    } else {
-      var brightness = value * 100;
+  async onCapabilityDim(value, opts, callback) {
+    let brightness = value === 0 ? 1 : value * 100;
+    let overWriteDimVal;
+
+    // Logic which will toggle between night_mode and normal_mode when brightness is set to 0 or 100 two times within 5 seconds
+    if(this.hasCapability('night_mode') && opts.duration === undefined) {
+      if (value === 0) {
+        if (this.dimMinTime + 5000 > Date.now()) {
+          const initialNightModeValue = this.getCapabilityValue('night_mode');
+          await this.triggerCapabilityListener('night_mode', true);
+          // If we think we really toggled the night mode we will set the brightness of night mode to 100
+          if(initialNightModeValue === false) {
+            value = 1;
+            overWriteDimVal = 1;
+            brightness = 100;
+          }
+          this.dimMinTime = 0;
+        }else {
+          this.dimMinTime = Date.now();
+        }
+      }else if (value === 1){
+        if (this.dimMaxTime + 5000 > Date.now()) {
+          const initialNightModeValue = this.getCapabilityValue('night_mode');
+          await this.triggerCapabilityListener('night_mode', false);
+          // If we think we really toggled the night mode we will set the brightness of normal mode to 1
+          if(initialNightModeValue === true) {
+            value = 0;
+            overWriteDimVal = 0;
+            brightness = 1;
+          }
+          this.dimMaxTime = 0;
+        }else {
+          this.dimMaxTime = Date.now();
+        }
+      }else {
+        this.dimMinTime = 0;
+        this.dimMaxTime = 0;
+      }
     }
+
     if(typeof opts.duration !== 'undefined') {
       this.sendCommand(this.getData().id, '{"id":1,"method":"set_bright","params":['+ brightness +', "smooth", '+ opts.duration +']}');
     } else {
       this.sendCommand(this.getData().id, '{"id":1,"method":"set_bright","params":['+ brightness +', "smooth", 500]}');
     }
     callback(null, value);
+
+    // "hack" to fix dim bar behaviour in the homey UI
+    if(overWriteDimVal !== undefined) {
+      this.setCapabilityValue('dim', overWriteDimVal);
+    }
   }
 
   onCapabilityHueSaturation(valueObj, optsObj) {


### PR DESCRIPTION
Depends on: #41 

Added logic to automatically toggle nightmode when dimming the device to 100/0 percent twice in a row within 5 seconds. This is usefull when controlling the device from your mobile phone (using the new app) so you can toggle night_mode without executing a flow.