### PR TITLE
Fix/connection errors

### DIFF
--- a/drivers/yeelights/device.js
+++ b/drivers/yeelights/device.js
@@ -257,7 +257,9 @@ class YeelightDevice extends Homey.Device {
 
   /* send commands to devices using their socket connection */
   sendCommand(id, command) {
-  	if (yeelights[id].connected === false && yeelights[id].socket !== null) {
+    if(yeelights[id].connecting && yeelights[id].connected === false){
+      this.log('Unable to send command because socket is still connecting');
+    } else if (yeelights[id].connected === false && yeelights[id].socket !== null) {
       yeelights[id].socket.emit('error', new Error('Connection to device broken'));
     } else if (yeelights[id].socket === null) {
       this.log('Unable to send command because socket is not available');
@@ -269,7 +271,7 @@ class YeelightDevice extends Homey.Device {
         if (yeelights[id].connected === true && yeelights[id].socket !== null) {
           yeelights[id].socket.emit('error', new Error('Error sending command'));
         }
-      }, 3000);
+      }, 6000);
     }
   }
 

--- a/drivers/yeelights/device.js
+++ b/drivers/yeelights/device.js
@@ -264,13 +264,12 @@ class YeelightDevice extends Homey.Device {
   	} else {
       yeelights[id].socket.write(command + '\r\n');
 
-      if (yeelights[id].timeout === null) {
-        yeelights[id].timeout = setTimeout(() => {
-          if (yeelights[id].connected === true && yeelights[id].socket !== null) {
-            yeelights[id].socket.emit('error', new Error('Error sending command'));
-          }
-        }, 3000);
-      }
+      clearTimeout(yeelights[id].timeout);
+      yeelights[id].timeout = setTimeout(() => {
+        if (yeelights[id].connected === true && yeelights[id].socket !== null) {
+          yeelights[id].socket.emit('error', new Error('Error sending command'));
+        }
+      }, 3000);
     }
   }
 


### PR DESCRIPTION
Depends on: #39 

During my testing I frequently got in an connection error state.
The first error state this commit fixes is when sending a command to a bulb while it is still connecting (e.g. startup or reconnect) it will emit an 'error' event on the socket (Error: Connection to device broken) but would not attempt to reconnect to the device
Secondly, when sending multiple commands the ceiling light commands did frequently take more than 3000 milliseconds to execute triggering the 'Error sending command' error. However, most of the time this command would still come through indicating the connection was not broken. Therefore I increased the timeout which triggers this error to 6000 seconds.