### PR TITLE
Corrected mode set_properties for airp_meb1 (Elite Smart Air Purifier)

### DIFF
--- a/drivers/airpurifier_zhimi_advanced_miot/device.js
+++ b/drivers/airpurifier_zhimi_advanced_miot/device.js
@@ -240,7 +240,7 @@ const properties = {
     "set_properties": {
       "power": { siid: 2, piid: 1 },
       "fanlevel": { siid: 2, piid: 5 },
-      "mode": { siid: 2, piid: 5 },
+      "mode": { siid: 2, piid: 4 },
       "buzzer": { siid: 6, piid: 1 },
       "child_lock": { siid: 8, piid: 1 },
       "light": { siid: 13, piid: 2 }


### PR DESCRIPTION
In the [spec](https://home.miot-spec.com/spec/zhimi.airp.meb1) for the Elite Purifier, the Mode is PIID 4 (0 - Auto // 1 - Sleep // 2 - Favorite // 3 - Manual), but in the code [it was mapped to PIID 5 (Line 243](https://github.com/jghaanstra/com.xiaomi-miio/blob/master/drivers/airpurifier_zhimi_advanced_miot/device.js?plain=1#L243) for the set_properties method, whereas the getter method is correct.