### PR TITLE
Add support for Chinese model of Aqara mini switch

### DIFF
--- a/drivers/aqara-button/driver.js
+++ b/drivers/aqara-button/driver.js
@@ -14,11 +14,11 @@ class AqaraButton extends Driver {
     this.homey.flow.getDeviceTriggerCard('click_long');
 
     this.config = {
-      model: ["sensor_switch.aq2", "sensor_switch"]
+      model: ["sensor_switch.aq2", "sensor_switch", "remote.b1acn01"]
     }
-    
+
   }
-  
+
 }
 
 module.exports = AqaraButton;

--- a/lib/util.js
+++ b/lib/util.js
@@ -22,7 +22,7 @@ class Util {
     'zhimi.airpurifier.mc1': 'Air Purifier 2S',
     'zhimi.airpurifier.mc2': 'Air Purifier 2H',
 
-    'zhimi.airpurifier.ma4': 'Air Purifier 3', 
+    'zhimi.airpurifier.ma4': 'Air Purifier 3',
     'zhimi.airpurifier.mb3': 'Air Purifier 3H',
     'zhimi.airpurifier.mb3a': 'Air Purifier 3H',
     'zhimi.airp.mb3a': 'Air Purifier 3H',
@@ -62,7 +62,7 @@ class Util {
 
     'xiaomi.humidifier.airmx': 'Mijia Mistless Humidifier 3 Pro',
     'xiaomi.humidifier.3lite': 'Xiaomi Smart Humidifier 3 Lite',
-    
+
     'deerma.humidifier.jsq': 'Mijia Smart Sterilization Humidifier JSQ',
     'deerma.humidifier.jsq1': 'Mijia Pure Smart Humidifier JSQ1',
     'deerma.humidifier.mjjsq': 'Mijia Smart Sterilization Humidifier MJJSQ',
@@ -210,7 +210,7 @@ class Util {
     'philips.light.mono1': 'Philips Light Bulb',
     'philips.light.downlight': 'Philips Down Light',
     'philips.light.strip5': 'Philips / Xiaomi Smart Lightstrip Pro',
-    
+
     'lumi.gateway.v2': 'Xiaomi Gateway v1',
     'lumi.gateway.v3': 'Xiaomi Gateway v2',
     'lumi.gateway.mcn001': 'Xiaomi Smart Home Hub 2',
@@ -219,7 +219,7 @@ class Util {
     'lumi.acpartner.v3': 'Aqara Gateway v3',
     'chuangmi.remote.v2': 'Universal Intelligent IR Remote Controller',
 
-    'mmgg.pet_waterer.s1': 'Xiaowan Smart Pet Water Dispenser', 
+    'mmgg.pet_waterer.s1': 'Xiaowan Smart Pet Water Dispenser',
     'mmgg.pet_waterer.s4': 'Xiaowan Smart Pet Water Dispenser',
     'mmgg.pet_waterer.wi11': 'Xiaomi Smart Pet Fountain',
     'xiaomi.pet_waterer.iv02': 'Xiaomi Smart Pet Fountain 2',
@@ -246,6 +246,7 @@ class Util {
     'sensor_switch.aq2': 'Aqara Wireless Button',
     'sensor_switch.aq3': 'Aqara Wireless Button (Advanced)',
     'sensor_switch': 'Aqara Wireless Button',
+    'remote.b1acn01': 'Aqara Wireless Button',
     'ctrl_ln1.aq1': 'Aqara Smart Wall Single Switch With Neutral',
     'switch_b1nacn02': 'Aqara Smart Wall Single Switch With Neutral',
     'ctrl_ln1.aq2': 'Aqara Smart Wall Double Switch With Neutral',


### PR DESCRIPTION
I have some Aqara mini switches which are not detected since apparently they emit a different model (https://www.aqara.com/eu/product/wireless-mini-switch/ precisely the: WXKG11LM)

It appears my editor also removes trailing whitespaces, sorry for that.