### PR TITLE
[codex] Add percentage speed for Smartmi Fan 3

### DIFF
--- a/.homeycompose/capabilities/fan_zhimi_percentage_speed.json
+++ b/.homeycompose/capabilities/fan_zhimi_percentage_speed.json
@@ -1,0 +1,26 @@
+{
+  "type": "number",
+  "title": {
+    "en": "Fan Speed (%)",
+    "nl": "Ventilatorsnelheid (%)",
+    "da": "Ventilatorhastighed (%)",
+    "de": "Lüftergeschwindigkeit (%)",
+    "es": "Velocidad del ventilador (%)",
+    "fr": "Vitesse du ventilateur (%)",
+    "it": "Velocità ventola (%)",
+    "no": "Viftehastighet (%)",
+    "sv": "Fläkthastighet (%)",
+    "pl": "Prędkość wentylatora (%)",
+    "ru": "Скорость вентилятора (%)",
+    "ko": "팬 속도 (%)"
+  },
+  "getable": true,
+  "setable": true,
+  "min": 1,
+  "max": 100,
+  "step": 1,
+  "units": {
+    "en": "%"
+  },
+  "icon": "/assets/icons/fanlevel.svg"
+}

--- a/app.json
+++ b/app.json
@@ -17768,6 +17768,7 @@
         "oscillating",
         "onoff.ion",
         "fan_speed",
+        "fan_zhimi_percentage_speed",
         "fan_zhimi_angle",
         "fan_zhimi_mode",
         "measure_humidity",
@@ -31029,6 +31030,32 @@
       ],
       "getable": true,
       "setable": true,
+      "icon": "/assets/icons/fanlevel.svg"
+    },
+    "fan_zhimi_percentage_speed": {
+      "type": "number",
+      "title": {
+        "en": "Fan Speed (%)",
+        "nl": "Ventilatorsnelheid (%)",
+        "da": "Ventilatorhastighed (%)",
+        "de": "Lüftergeschwindigkeit (%)",
+        "es": "Velocidad del ventilador (%)",
+        "fr": "Vitesse du ventilateur (%)",
+        "it": "Velocità ventola (%)",
+        "no": "Viftehastighet (%)",
+        "sv": "Fläkthastighet (%)",
+        "pl": "Prędkość wentylatora (%)",
+        "ru": "Скорость вентилятора (%)",
+        "ko": "팬 속도 (%)"
+      },
+      "getable": true,
+      "setable": true,
+      "min": 1,
+      "max": 100,
+      "step": 1,
+      "units": {
+        "en": "%"
+      },
       "icon": "/assets/icons/fanlevel.svg"
     },
     "heater_zhimi_heater_target_temperature": {

--- a/drivers/fan_zhimi_fan_za5/device.js
+++ b/drivers/fan_zhimi_fan_za5/device.js
@@ -19,6 +19,7 @@ const params = [
   { did: "buzzer", siid: 5, piid: 1 }, // settings.buzzer
   { did: "humidity", siid: 7, piid: 1 }, // measure_humidity
   { did: "temperature", siid: 7, piid: 7 }, // measure_temperature
+  { did: "percentage_speed", siid: 6, piid: 8 }, // fan_zhimi_percentage_speed
 ];
 
 const modes = {
@@ -32,6 +33,10 @@ class ZhiMiFanZA5Device extends Device {
     try {
       if (!this.util) this.util = new Util({homey: this.homey});
       
+      if (!this.hasCapability('fan_zhimi_percentage_speed')) {
+        await this.addCapability('fan_zhimi_percentage_speed');
+      }
+
       // GENERIC DEVICE INIT ACTIONS
       this.bootSequence();
 
@@ -88,6 +93,22 @@ class ZhiMiFanZA5Device extends Device {
         try {
           if (this.miio) {
             return await this.miio.call("set_properties", [{ siid: 2, piid: 2, value: value }], { retries: 1 });
+          } else {
+            this.setUnavailable(this.homey.__('unreachable')).catch(error => { this.error(error) });
+            this.createDevice();
+            return Promise.reject('Device unreachable, please try again ...');
+          }
+        } catch (error) {
+          this.error(error);
+          return Promise.reject(error);
+        }
+      });
+
+      this.registerCapabilityListener('fan_zhimi_percentage_speed', async ( value ) => {
+        try {
+          if (this.miio) {
+            const speed = this.util.clamp(Math.round(Number(value)), 1, 100);
+            return await this.miio.call("set_properties", [{ siid: 6, piid: 8, value: speed }], { retries: 1 });
           } else {
             this.setUnavailable(this.homey.__('unreachable')).catch(error => { this.error(error) });
             this.createDevice();
@@ -165,6 +186,7 @@ class ZhiMiFanZA5Device extends Device {
       const oscillating = result.find(obj => obj.did === 'swing_mode');
       const onoff_ion = result.find(obj => obj.did === 'anion');
       const fan_zhimi_angle = result.find(obj => obj.did === 'swing_mode_angle');
+      const percentage_speed = result.find(obj => obj.did === 'percentage_speed');
       const measure_humidity = result.find(obj => obj.did === 'humidity');
       const measure_temperature = result.find(obj => obj.did === 'temperature');
 
@@ -175,6 +197,9 @@ class ZhiMiFanZA5Device extends Device {
       /* capabilities */
       await this.updateCapabilityValue("onoff", onoff.value);
       await this.updateCapabilityValue("fan_speed", fan_speed.value);
+      if (percentage_speed !== undefined && this.hasCapability('fan_zhimi_percentage_speed')) {
+        await this.updateCapabilityValue("fan_zhimi_percentage_speed", percentage_speed.value);
+      }
       await this.updateCapabilityValue("oscillating", oscillating.value);
       await this.updateCapabilityValue("onoff.ion", onoff_ion.value);
       await this.updateCapabilityValue("fan_zhimi_angle", fan_zhimi_angle.value.toString());

--- a/drivers/fan_zhimi_fan_za5/driver.compose.json
+++ b/drivers/fan_zhimi_fan_za5/driver.compose.json
@@ -26,6 +26,7 @@
     "oscillating",
     "onoff.ion",
     "fan_speed",
+    "fan_zhimi_percentage_speed",
     "fan_zhimi_angle",
     "fan_zhimi_mode",
     "measure_humidity",


### PR DESCRIPTION
## Summary
- add a new fan_zhimi_percentage_speed custom capability with 1-100% range
- expose the capability on the Smartmi Standing Fan 3 (zhimi.fan.za5) driver without changing the existing 1-4 fan_speed level capability
- read and write MIoT custom-service speed-level through siid 6 / piid 8
- add the capability automatically for existing paired ZA5 devices

## Compatibility
The existing fan_speed capability remains unchanged at levels 1-4, so existing devices and flows keep their current behavior.

## Validation
- node --check drivers/fan_zhimi_fan_za5/device.js
- homey app validate