### PR TITLE
[codex] Add Xiaomi Robot Vacuum S40 Pro support

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -493,5 +493,8 @@
   },
   "3.4.86": {
     "en": "Add percentage speed for Smartmi Fan 3"
+  },
+  "3.4.87": {
+    "en": "Add Xiaomi Robot Vacuum S40 Pro support"
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -186,7 +186,7 @@
       "게이트웨이"
     ]
   },
-  "version": "3.4.86",
+  "version": "3.4.87",
   "compatibility": ">=12.2.0",
   "platforms": [
     "local"

--- a/app.json
+++ b/app.json
@@ -187,7 +187,7 @@
       "게이트웨이"
     ]
   },
-  "version": "3.4.86",
+  "version": "3.4.87",
   "compatibility": ">=12.2.0",
   "platforms": [
     "local"

--- a/drivers/vacuum_xiaomi_vacuum_max/device.js
+++ b/drivers/vacuum_xiaomi_vacuum_max/device.js
@@ -11,6 +11,7 @@ const Util = require('../../lib/util.js');
 // https://home.miot-spec.com/spec/xiaomi.vacuum.c102gl // Xiaomi Robot Vacuum X20 / X20+
 // https://home.miot-spec.com/spec/xiaomi.vacuum.b108gl // Xiaomi Robot Vacuum S20+
 // https://home.miot-spec.com/spec/xiaomi.vacuum.ov51gl // Xiaomi Robot Vacuum H40
+// https://home.miot-spec.com/spec/xiaomi.vacuum.ov71gl // Xiaomi Robot Vacuum S40 Pro
 // https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:vacuum:0000A006:xiaomi-c108:1 // Xiaomi Robot Vacuum E5
 /** ------------------------------------------------------------------
  *  Shared constants (hoisted)
@@ -110,6 +111,7 @@ const mapping = {
     'xiaomi.vacuum.d101': 'properties_d101',
     'xiaomi.vacuum.d101gl': 'properties_d101',
     'xiaomi.vacuum.ov51gl': 'properties_d101',
+    'xiaomi.vacuum.ov71gl': 'properties_d101',
     'xiaomi.vacuum.c102gl': 'properties_c102gl', // X20 / X20+ specific minimal + room action change
     'xiaomi.vacuum.b108gl': 'properties_b108gl',
     'xiaomi.vacuum.c108': 'properties_c108'

--- a/lib/util.js
+++ b/lib/util.js
@@ -182,6 +182,7 @@ class Util {
     'xiaomi.vacuum.d101': 'Xiaomi Robot Vacuum H40',
     'xiaomi.vacuum.d101gl': 'Xiaomi Robot Vacuum H40 (CN)',
     'xiaomi.vacuum.ov51gl': 'Xiaomi Robot Vacuum H40 (EU)',
+    'xiaomi.vacuum.ov71gl': 'Xiaomi Robot Vacuum S40 Pro',
     'xiaomi.vacuum.b108gl': 'Xiaomi Robot Vacuum S20+',
     'xiaomi.vacuum.c108': 'Xiaomi Robot Vacuum E5',
 


### PR DESCRIPTION
## Summary

Adds support for `xiaomi.vacuum.ov71gl` / Xiaomi Robot Vacuum S40 Pro in the Xiaomi Vacuum Cleaner MIoT MAX driver.

## Details

- Maps `xiaomi.vacuum.ov71gl` to the existing H40/D101 MIOT property set after checking the MIOT spec compatibility.
- Adds the friendly model name for pairing/device identification.
- Updates the GitHub wiki supported devices page separately with the S40 Pro row.

## Validation

- `node --check drivers/vacuum_xiaomi_vacuum_max/device.js`
- `node --check lib/util.js`
- `homey app validate`