### PR TITLE
Fix Monitor Light Bar S1 mode flow trigger and labels

### DIFF
--- a/.homeycompose/capabilities/yeelight_lamp22_mode.json
+++ b/.homeycompose/capabilities/yeelight_lamp22_mode.json
@@ -11,8 +11,8 @@
     {
       "id": "0",
       "title": {
-        "en": "Free mode",
-        "nl": "Vrije modus"
+        "en": "No mode",
+        "nl": "Geen modus"
       }
     },
     {
@@ -44,13 +44,6 @@
       }
     },
     {
-      "id": "5",
-      "title": {
-        "en": "Reading",
-        "nl": "Lezen"
-      }
-    },
-    {
       "id": "6",
       "title": {
         "en": "Office",
@@ -58,17 +51,17 @@
       }
     },
     {
-      "id": "7",
+      "id": "5",
       "title": {
-        "en": "Movie",
-        "nl": "Film"
+        "en": "Reading",
+        "nl": "Lezen"
       }
     },
     {
-      "id": "8",
+      "id": "7",
       "title": {
-        "en": "Warm",
-        "nl": "Warm"
+        "en": "Leisure",
+        "nl": "Ontspanning"
       }
     },
     {
@@ -76,6 +69,13 @@
       "title": {
         "en": "Computer",
         "nl": "Computer"
+      }
+    },
+    {
+      "id": "8",
+      "title": {
+        "en": "Warm",
+        "nl": "Warm"
       }
     },
     {

--- a/.homeycompose/flow/actions/yeelightLamp22Mode.json
+++ b/.homeycompose/flow/actions/yeelightLamp22Mode.json
@@ -19,8 +19,8 @@
         {
           "id": "0",
           "title": {
-            "en": "Free mode",
-            "nl": "Vrije modus"
+            "en": "No mode",
+            "nl": "Geen modus"
           }
         },
         {
@@ -52,13 +52,6 @@
           }
         },
         {
-          "id": "5",
-          "title": {
-            "en": "Reading",
-            "nl": "Lezen"
-          }
-        },
-        {
           "id": "6",
           "title": {
             "en": "Office",
@@ -66,17 +59,17 @@
           }
         },
         {
-          "id": "7",
+          "id": "5",
           "title": {
-            "en": "Movie",
-            "nl": "Film"
+            "en": "Reading",
+            "nl": "Lezen"
           }
         },
         {
-          "id": "8",
+          "id": "7",
           "title": {
-            "en": "Warm",
-            "nl": "Warm"
+            "en": "Leisure",
+            "nl": "Ontspanning"
           }
         },
         {
@@ -84,6 +77,13 @@
           "title": {
             "en": "Computer",
             "nl": "Computer"
+          }
+        },
+        {
+          "id": "8",
+          "title": {
+            "en": "Warm",
+            "nl": "Warm"
           }
         },
         {

--- a/.homeycompose/flow/conditions/yeelightLamp22ModeIs.json
+++ b/.homeycompose/flow/conditions/yeelightLamp22ModeIs.json
@@ -19,8 +19,8 @@
         {
           "id": "0",
           "title": {
-            "en": "Free mode",
-            "nl": "Vrije modus"
+            "en": "No mode",
+            "nl": "Geen modus"
           }
         },
         {
@@ -52,13 +52,6 @@
           }
         },
         {
-          "id": "5",
-          "title": {
-            "en": "Reading",
-            "nl": "Lezen"
-          }
-        },
-        {
           "id": "6",
           "title": {
             "en": "Office",
@@ -66,17 +59,17 @@
           }
         },
         {
-          "id": "7",
+          "id": "5",
           "title": {
-            "en": "Movie",
-            "nl": "Film"
+            "en": "Reading",
+            "nl": "Lezen"
           }
         },
         {
-          "id": "8",
+          "id": "7",
           "title": {
-            "en": "Warm",
-            "nl": "Warm"
+            "en": "Leisure",
+            "nl": "Ontspanning"
           }
         },
         {
@@ -84,6 +77,13 @@
           "title": {
             "en": "Computer",
             "nl": "Computer"
+          }
+        },
+        {
+          "id": "8",
+          "title": {
+            "en": "Warm",
+            "nl": "Warm"
           }
         },
         {

--- a/.homeycompose/flow/triggers/yeelightLamp22ModeChanged.json
+++ b/.homeycompose/flow/triggers/yeelightLamp22ModeChanged.json
@@ -7,10 +7,6 @@
     "en": "My mode / scene changed to [[mode]]",
     "nl": "Mijn modus / scene gewijzigd naar [[mode]]"
   },
-  "hint": {
-    "en": "External changes are detected after the next polling interval. The polling interval can be adjusted in the device settings.",
-    "nl": "Externe wijzigingen worden na het volgende polling-interval gedetecteerd. Het polling-interval kan in de apparaatinstellingen worden aangepast."
-  },
   "tokens": [
     {
       "name": "mode",
@@ -43,8 +39,8 @@
         {
           "id": "0",
           "title": {
-            "en": "Free mode",
-            "nl": "Vrije modus"
+            "en": "No mode",
+            "nl": "Geen modus"
           }
         },
         {
@@ -76,13 +72,6 @@
           }
         },
         {
-          "id": "5",
-          "title": {
-            "en": "Reading",
-            "nl": "Lezen"
-          }
-        },
-        {
           "id": "6",
           "title": {
             "en": "Office",
@@ -90,17 +79,17 @@
           }
         },
         {
-          "id": "7",
+          "id": "5",
           "title": {
-            "en": "Movie",
-            "nl": "Film"
+            "en": "Reading",
+            "nl": "Lezen"
           }
         },
         {
-          "id": "8",
+          "id": "7",
           "title": {
-            "en": "Warm",
-            "nl": "Warm"
+            "en": "Leisure",
+            "nl": "Ontspanning"
           }
         },
         {
@@ -108,6 +97,13 @@
           "title": {
             "en": "Computer",
             "nl": "Computer"
+          }
+        },
+        {
+          "id": "8",
+          "title": {
+            "en": "Warm",
+            "nl": "Warm"
           }
         },
         {

--- a/drivers/yeelink_light_lamp22_miot/device.js
+++ b/drivers/yeelink_light_lamp22_miot/device.js
@@ -12,14 +12,14 @@ const MODE_CAPABILITY = 'yeelight_lamp22_mode';
 const LEGACY_LIGHT_MODE_CAPABILITY = 'yeelight_lamp22_light_mode';
 const SCENE_MODE_VALUES = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10'];
 const SCENE_MODE_OPTIONS = [
-  { id: '0', title: 'Free mode' },
+  { id: '0', title: 'No mode' },
   { id: '1', title: 'My mode 1' },
   { id: '2', title: 'My mode 2' },
   { id: '3', title: 'My mode 3' },
   { id: '4', title: 'My mode 4' },
   { id: '5', title: 'Reading' },
   { id: '6', title: 'Office' },
-  { id: '7', title: 'Movie' },
+  { id: '7', title: 'Leisure' },
   { id: '8', title: 'Warm' },
   { id: '9', title: 'Computer' },
   { id: '10', title: 'Blinking' }
@@ -63,7 +63,7 @@ class XiaomiMonitorLightBarS1Device extends Device {
       await this.ensureCapability(MODE_CAPABILITY);
 
       this.registerCapabilityListener('onoff', (value) => this.setMiotProperty('power', value));
-      this.registerCapabilityListener(MODE_CAPABILITY, (value) => this.setMiotProperty('scene_mode', Number(value)));
+      this.registerCapabilityListener(MODE_CAPABILITY, (value) => this.onModeCapability(value));
 
       this.registerMultipleCapabilityListener(
         ['dim', 'light_temperature'],
@@ -120,6 +120,15 @@ class XiaomiMonitorLightBarS1Device extends Device {
 
     if (typeof valueObj.light_temperature !== 'undefined') {
       await this.setMiotProperty('color_temperature', this.toMiotColorTemperature(valueObj.light_temperature));
+    }
+  }
+
+  async onModeCapability(value) {
+    const previousValue = this.getCapabilityValue(MODE_CAPABILITY);
+    await this.setMiotProperty('scene_mode', Number(value));
+
+    if (String(previousValue) !== String(value)) {
+      await this.triggerModeChanged(value, previousValue);
     }
   }
 


### PR DESCRIPTION
Thank you for such a quick adoption, whilst taking the time to go through both the previous PRs for the Monitor Lightbar S1 and Yeelight (legacy) color bulb.

After doing some extensive testing today, I have one PR for tweaks/small fixes:

### Changes For Legacy Lan color bulb
- None. Testing is done. No issues found.

### Changes: For the lightbar S1:
- Fix 'when card' triggering
- Tweaking of labels
- Removed flowcard info field

**Fix 'when card' triggering**
Today, I found out that the unique 'when: scene changed to <my mode/scene>' was only triggered when the user would update to the scene via the external source (native Xiaomi app). It would not trigger when user selected the scene via the Homey app. In this PR I fix this issue: it now triggers in both scenarios.

**Tweaking of labels**
I liked your shortening of the labels. It looks much better! I tweaked it further: I made sure they are now named and ordered in the exact same way as the user seems them in the native Xiaomi app. I also renamed the 'Free Mode' to 'No Scene', as it made slightly more sense to me when using the flow cards. If you disagree: don't hesitate to change it.

**Removed flowcard info field**
The unique 'when: scene changed to <my mode/scene>' flow card had an info message (explaining about the effect of the polling mechanism). Seeing it in the homey store, it made no sense, and sounded like a 'only works half/difficult'. I removed this info. It is not needed/overkill.