### PR TITLE
Advanced Xiaomi Fan MIoT improvements

### DIFF
--- a/.homeycompose/capabilities/fan_xiaomi_fanlevel.json
+++ b/.homeycompose/capabilities/fan_xiaomi_fanlevel.json
@@ -1,7 +1,7 @@
 {
   "type": "enum",
   "title": {
-    "en": "Fanlevel",
+    "en": "Fan level",
     "nl": "Ventilator niveau",
     "da": "Fan niveau",
     "de": "Ventilatorebene",

--- a/.homeycompose/capabilities/fan_xiaomi_fanlevel.json
+++ b/.homeycompose/capabilities/fan_xiaomi_fanlevel.json
@@ -18,7 +18,13 @@
     { "id": "1", "title": { "en": "1" } },
     { "id": "2", "title": { "en": "2" } },
     { "id": "3", "title": { "en": "3" } },
-    { "id": "4", "title": { "en": "4" } }
+    { "id": "4", "title": { "en": "4" } },
+    { "id": "5", "title": { "en": "5" } },
+    { "id": "6", "title": { "en": "6" } },
+    { "id": "7", "title": { "en": "7" } },
+    { "id": "8", "title": { "en": "8" } },
+    { "id": "9", "title": { "en": "9" } },
+    { "id": "10", "title": { "en": "10" } }
   ],
   "getable": true,
   "setable": true,

--- a/.homeycompose/drivers/flow/actions/xiaomiFanLevelSet.json
+++ b/.homeycompose/drivers/flow/actions/xiaomiFanLevelSet.json
@@ -1,0 +1,53 @@
+{
+  "id": "xiaomiFanLevelSet",
+  "$filter": "capabilities=fan_xiaomi_fanlevel",
+  "title": {
+    "en": "Set fan level",
+    "nl": "Stel ventilatorniveau in",
+    "da": "Indstil ventilatorniveau",
+    "de": "Ventilatorstufe einstellen",
+    "es": "Configurar nivel del ventilador",
+    "fr": "Définir le niveau du ventilateur",
+    "it": "Imposta livello del ventilatore",
+    "no": "Sett viftenivå",
+    "sv": "Ställ in fläktnivå",
+    "pl": "Ustaw poziom wentylatora",
+    "ru": "Установить уровень вентилятора",
+    "ko": "팬 레벨 설정"
+  },
+  "titleFormatted": {
+    "en": "Set fan level to [[level]]",
+    "nl": "Stel ventilatorniveau in op [[level]]",
+    "da": "Indstil ventilatorniveau til [[level]]",
+    "de": "Ventilatorstufe auf [[level]] einstellen",
+    "es": "Configurar nivel del ventilador en [[level]]",
+    "fr": "Définir le niveau du ventilateur sur [[level]]",
+    "it": "Imposta livello del ventilatore su [[level]]",
+    "no": "Sett viftenivå til [[level]]",
+    "sv": "Ställ in fläktnivå till [[level]]",
+    "pl": "Ustaw poziom wentylatora na [[level]]",
+    "ru": "Установить уровень вентилятора на [[level]]",
+    "ko": "팬 레벨을 [[level]](으)로 설정"
+  },
+  "args": [
+    {
+      "name": "level",
+      "title": {
+        "en": "Fan level",
+        "nl": "Ventilatorniveau",
+        "da": "Ventilatorniveau",
+        "de": "Ventilatorstufe",
+        "es": "Nivel del ventilador",
+        "fr": "Niveau du ventilateur",
+        "it": "Livello del ventilatore",
+        "no": "Viftenivå",
+        "sv": "Fläktnivå",
+        "pl": "Poziom wentylatora",
+        "ru": "Уровень вентилятора",
+        "ko": "팬 레벨"
+      },
+      "type": "autocomplete"
+    }
+  ],
+  "platforms": ["local"]
+}

--- a/.homeycompose/drivers/flow/actions/xiaomiFanMode.json
+++ b/.homeycompose/drivers/flow/actions/xiaomiFanMode.json
@@ -1,7 +1,7 @@
 {
   "id": "xiaomiFanMode",
   "title": {
-    "en": "Set Mode",
+    "en": "Set mode",
     "nl": "Stel modus in",
     "da": "Indstil tilstand",
     "de": "Modus einstellen",

--- a/.homeycompose/drivers/flow/actions/xiaomiHorizontalSwingOff.json
+++ b/.homeycompose/drivers/flow/actions/xiaomiHorizontalSwingOff.json
@@ -2,7 +2,7 @@
   "id": "xiaomiHorizontalSwingOff",
   "$filter": "capabilities=fan_xiaomi_horizontal_swing",
   "title": {
-    "en": "Disable Horizontal Swing",
+    "en": "Disable horizontal swing",
     "nl": "Horizontale oscillatie uitschakelen",
     "da": "Deaktivér vandret oscillation",
     "de": "Horizontale Oszillation deaktivieren",
@@ -16,7 +16,7 @@
     "ko": "수평 진동 비활성화"
   },
   "titleFormatted": {
-    "en": "Disable Horizontal Swing",
+    "en": "Disable horizontal swing",
     "nl": "Horizontale oscillatie uitschakelen",
     "da": "Deaktivér vandret oscillation",
     "de": "Horizontale Oszillation deaktivieren",

--- a/.homeycompose/drivers/flow/actions/xiaomiHorizontalSwingOn.json
+++ b/.homeycompose/drivers/flow/actions/xiaomiHorizontalSwingOn.json
@@ -2,7 +2,7 @@
   "id": "xiaomiHorizontalSwingOn",
   "$filter": "capabilities=fan_xiaomi_horizontal_swing",
   "title": {
-    "en": "Enable Horizontal Swing",
+    "en": "Enable horizontal swing",
     "nl": "Horizontale oscillatie inschakelen",
     "da": "Aktivér vandret oscillation",
     "de": "Horizontale Oszillation aktivieren",
@@ -16,7 +16,7 @@
     "ko": "수평 진동 활성화"
   },
   "titleFormatted": {
-    "en": "Enable Horizontal Swing",
+    "en": "Enable horizontal swing",
     "nl": "Horizontale oscillatie inschakelen",
     "da": "Aktivér vandret oscillation",
     "de": "Horizontale Oszillation aktivieren",

--- a/.homeycompose/drivers/flow/actions/xiaomiHorizontalSwingToggle.json
+++ b/.homeycompose/drivers/flow/actions/xiaomiHorizontalSwingToggle.json
@@ -2,7 +2,7 @@
   "id": "xiaomiHorizontalSwingToggle",
   "$filter": "capabilities=fan_xiaomi_horizontal_swing",
   "title": {
-    "en": "Toggle Horizontal Swing",
+    "en": "Toggle horizontal swing",
     "nl": "Horizontale oscillatie omschakelen",
     "da": "Skift vandret oscillation",
     "de": "Horizontale Oszillation umschalten",
@@ -16,7 +16,7 @@
     "ko": "수평 진동 전환"
   },
   "titleFormatted": {
-    "en": "Toggle Horizontal Swing",
+    "en": "Toggle horizontal swing",
     "nl": "Horizontale oscillatie omschakelen",
     "da": "Skift vandret oscillation",
     "de": "Horizontale Oszillation umschalten",

--- a/.homeycompose/drivers/flow/actions/xiaomiSetFanLevel.json
+++ b/.homeycompose/drivers/flow/actions/xiaomiSetFanLevel.json
@@ -1,5 +1,5 @@
 {
-  "id": "xiaomiFanLevelSet",
+  "id": "xiaomiSetFanLevel",
   "$filter": "capabilities=fan_xiaomi_fanlevel",
   "title": {
     "en": "Set fan level",

--- a/.homeycompose/drivers/flow/actions/xiaomiSetHorizontalAngle.json
+++ b/.homeycompose/drivers/flow/actions/xiaomiSetHorizontalAngle.json
@@ -2,7 +2,7 @@
   "id": "xiaomiSetHorizontalAngle",
   "$filter": "capabilities=fan_xiaomi_horizontal_angle",
   "title": {
-    "en": "Change Horizontal Swing Angle",
+    "en": "Change horizontal swing angle",
     "nl": "Horizontale draaihoek wijzigen",
     "da": "Skift vandret svingvinkel",
     "de": "Horizontalen Schwenkwinkel ändern",

--- a/.homeycompose/drivers/flow/actions/xiaomiSetVerticalAngle.json
+++ b/.homeycompose/drivers/flow/actions/xiaomiSetVerticalAngle.json
@@ -2,7 +2,7 @@
   "id": "xiaomiSetVerticalAngle",
   "$filter": "capabilities=fan_xiaomi_vertical_angle",
   "title": {
-    "en": "Change Vertical Swing Angle",
+    "en": "Change vertical swing angle",
     "nl": "Verticale draaihoek wijzigen",
     "da": "Skift lodret svingvinkel",
     "de": "Vertikalen Schwenkwinkel ändern",

--- a/.homeycompose/drivers/flow/actions/xiaomiVerticalSwingOff.json
+++ b/.homeycompose/drivers/flow/actions/xiaomiVerticalSwingOff.json
@@ -2,7 +2,7 @@
   "id": "xiaomiVerticalSwingOff",
   "$filter": "capabilities=fan_xiaomi_vertical_swing",
   "title": {
-    "en": "Disable Vertical Swing",
+    "en": "Disable vertical swing",
     "nl": "Verticale oscillatie uitschakelen",
     "da": "Deaktivér lodret oscillation",
     "de": "Vertikale Oszillation deaktivieren",
@@ -16,7 +16,7 @@
     "ko": "수직 진동 비활성화"
   },
   "titleFormatted": {
-    "en": "Disable Vertical Swing",
+    "en": "Disable vertical swing",
     "nl": "Verticale oscillatie uitschakelen",
     "da": "Deaktivér lodret oscillation",
     "de": "Vertikale Oszillation deaktivieren",

--- a/.homeycompose/drivers/flow/actions/xiaomiVerticalSwingOn.json
+++ b/.homeycompose/drivers/flow/actions/xiaomiVerticalSwingOn.json
@@ -2,7 +2,7 @@
   "id": "xiaomiVerticalSwingOn",
   "$filter": "capabilities=fan_xiaomi_vertical_swing",
   "title": {
-    "en": "Enable Vertical Swing",
+    "en": "Enable vertical swing",
     "nl": "Verticale oscillatie inschakelen",
     "da": "Aktivér lodret oscillation",
     "de": "Vertikale Oszillation aktivieren",
@@ -16,7 +16,7 @@
     "ko": "수직 진동 활성화"
   },
   "titleFormatted": {
-    "en": "Enable Vertical Swing",
+    "en": "Enable vertical swing",
     "nl": "Verticale oscillatie inschakelen",
     "da": "Aktivér lodret oscillation",
     "de": "Vertikale Oszillation aktivieren",

--- a/.homeycompose/drivers/flow/actions/xiaomiVerticalSwingToggle.json
+++ b/.homeycompose/drivers/flow/actions/xiaomiVerticalSwingToggle.json
@@ -2,7 +2,7 @@
   "id": "xiaomiVerticalSwingToggle",
   "$filter": "capabilities=fan_xiaomi_vertical_swing",
   "title": {
-    "en": "Toggle Vertical Swing",
+    "en": "Toggle vertical swing",
     "nl": "Verticale oscillatie omschakelen",
     "da": "Skift lodret oscillation",
     "de": "Vertikale Oszillation umschalten",
@@ -16,7 +16,7 @@
     "ko": "수직 진동 전환"
   },
   "titleFormatted": {
-    "en": "Toggle Vertical Swing",
+    "en": "Toggle vertical swing",
     "nl": "Verticale oscillatie omschakelen",
     "da": "Skift lodret oscillation",
     "de": "Vertikale Oszillation umschalten",

--- a/.homeycompose/drivers/flow/conditions/xiaomiFanLevelEquals.json
+++ b/.homeycompose/drivers/flow/conditions/xiaomiFanLevelEquals.json
@@ -1,0 +1,53 @@
+{
+  "id": "xiaomiFanLevelEquals",
+  "$filter": "capabilities=fan_xiaomi_fanlevel",
+  "title": {
+    "en": "Fan level !{{is|is not}}",
+    "nl": "Ventilatorniveau !{{is|is niet}}",
+    "da": "Ventilatorniveau !{{er|er ikke}}",
+    "de": "Ventilatorstufe !{{ist|ist nicht}}",
+    "es": "El nivel del ventilador !{{es|no es}}",
+    "fr": "Le niveau du ventilateur !{{est|n'est pas}}",
+    "it": "Il livello del ventilatore !{{è|non è}}",
+    "no": "Viftenivå !{{er|er ikke}}",
+    "sv": "Fläktnivå !{{är|är inte}}",
+    "pl": "Poziom wentylatora !{{jest|nie jest}}",
+    "ru": "Уровень вентилятора !{{равен|не равен}}",
+    "ko": "팬 레벨이 !{{임|아님}}"
+  },
+  "titleFormatted": {
+    "en": "Fan level !{{is|is not}} [[level]]",
+    "nl": "Ventilatorniveau !{{is|is niet}} [[level]]",
+    "da": "Ventilatorniveau !{{er|er ikke}} [[level]]",
+    "de": "Ventilatorstufe !{{ist|ist nicht}} [[level]]",
+    "es": "El nivel del ventilador !{{es|no es}} [[level]]",
+    "fr": "Le niveau du ventilateur !{{est|n'est pas}} [[level]]",
+    "it": "Il livello del ventilatore !{{è|non è}} [[level]]",
+    "no": "Viftenivå !{{er|er ikke}} [[level]]",
+    "sv": "Fläktnivå !{{är|är inte}} [[level]]",
+    "pl": "Poziom wentylatora !{{jest|nie jest}} [[level]]",
+    "ru": "Уровень вентилятора !{{равен|не равен}} [[level]]",
+    "ko": "팬 레벨이 [[level]] !{{임|아님}}"
+  },
+  "args": [
+    {
+      "name": "level",
+      "title": {
+        "en": "Fan level",
+        "nl": "Ventilatorniveau",
+        "da": "Ventilatorniveau",
+        "de": "Ventilatorstufe",
+        "es": "Nivel del ventilador",
+        "fr": "Niveau du ventilateur",
+        "it": "Livello del ventilatore",
+        "no": "Viftenivå",
+        "sv": "Fläktnivå",
+        "pl": "Poziom wentylatora",
+        "ru": "Уровень вентилятора",
+        "ko": "팬 레벨"
+      },
+      "type": "autocomplete"
+    }
+  ],
+  "platforms": ["local"]
+}

--- a/.homeycompose/drivers/flow/conditions/xiaomiHorizontalAngleEquals.json
+++ b/.homeycompose/drivers/flow/conditions/xiaomiHorizontalAngleEquals.json
@@ -1,0 +1,53 @@
+{
+  "id": "xiaomiHorizontalAngleEquals",
+  "$filter": "capabilities=fan_xiaomi_horizontal_angle",
+  "title": {
+    "en": "Horizontal angle !{{is|is not}}",
+    "nl": "Horizontale hoek !{{is|is niet}}",
+    "da": "Vandret vinkel !{{er|er ikke}}",
+    "de": "Horizontaler Winkel !{{ist|ist nicht}}",
+    "es": "El ángulo horizontal !{{es|no es}}",
+    "fr": "L'angle horizontal !{{est|n'est pas}}",
+    "it": "L'angolo orizzontale !{{è|non è}}",
+    "no": "Horisontal vinkel !{{er|er ikke}}",
+    "sv": "Horisontell vinkel !{{är|är inte}}",
+    "pl": "Kąt poziomy !{{jest|nie jest}}",
+    "ru": "Горизонтальный угол !{{равен|не равен}}",
+    "ko": "수평 각도가 !{{임|아님}}"
+  },
+  "titleFormatted": {
+    "en": "Horizontal angle !{{is|is not}} [[angle]]",
+    "nl": "Horizontale hoek !{{is|is niet}} [[angle]]",
+    "da": "Vandret vinkel !{{er|er ikke}} [[angle]]",
+    "de": "Horizontaler Winkel !{{ist|ist nicht}} [[angle]]",
+    "es": "El ángulo horizontal !{{es|no es}} [[angle]]",
+    "fr": "L'angle horizontal !{{est|n'est pas}} [[angle]]",
+    "it": "L'angolo orizzontale !{{è|non è}} [[angle]]",
+    "no": "Horisontal vinkel !{{er|er ikke}} [[angle]]",
+    "sv": "Horisontell vinkel !{{är|är inte}} [[angle]]",
+    "pl": "Kąt poziomy !{{jest|nie jest}} [[angle]]",
+    "ru": "Горизонтальный угол !{{равен|не равен}} [[angle]]",
+    "ko": "수평 각도가 [[angle]] !{{임|아님}}"
+  },
+  "args": [
+    {
+      "name": "angle",
+      "title": {
+        "en": "Angle",
+        "nl": "Hoek",
+        "da": "Vinkel",
+        "de": "Winkel",
+        "es": "Ángulo",
+        "fr": "Angle",
+        "it": "Angolo",
+        "no": "Vinkel",
+        "sv": "Vinkel",
+        "pl": "Kąt",
+        "ru": "Угол",
+        "ko": "각도"
+      },
+      "type": "autocomplete"
+    }
+  ],
+  "platforms": ["local"]
+}

--- a/.homeycompose/drivers/flow/conditions/xiaomiHorizontalSwingIsOn.json
+++ b/.homeycompose/drivers/flow/conditions/xiaomiHorizontalSwingIsOn.json
@@ -2,7 +2,7 @@
   "id": "xiaomiHorizontalSwingIsOn",
   "$filter": "capabilities=fan_xiaomi_horizontal_swing",
   "title": {
-    "en": "Horizontal Swing is !{{on|off}}",
+    "en": "Horizontal swing is !{{on|off}}",
     "nl": "Horizontale oscillatie is !{{aan|uit}}",
     "da": "Vandret oscillation er !{{tændt|slukket}}",
     "de": "Horizontale Oszillation ist !{{an|aus}}",

--- a/.homeycompose/drivers/flow/conditions/xiaomiModeEquals.json
+++ b/.homeycompose/drivers/flow/conditions/xiaomiModeEquals.json
@@ -1,0 +1,53 @@
+{
+  "id": "xiaomiModeEquals",
+  "$filter": "capabilities=fan_xiaomi_mode",
+  "title": {
+    "en": "Mode !{{is|is not}}",
+    "nl": "Modus !{{is|is niet}}",
+    "da": "Tilstand !{{er|er ikke}}",
+    "de": "Modus !{{ist|ist nicht}}",
+    "es": "El modo !{{es|no es}}",
+    "fr": "Le mode !{{est|n'est pas}}",
+    "it": "La modalità !{{è|non è}}",
+    "no": "Modus !{{er|er ikke}}",
+    "sv": "Läge !{{är|är inte}}",
+    "pl": "Tryb !{{jest|nie jest}}",
+    "ru": "Режим !{{равен|не равен}}",
+    "ko": "모드가 !{{임|아님}}"
+  },
+  "titleFormatted": {
+    "en": "Mode !{{is|is not}} [[mode]]",
+    "nl": "Modus !{{is|is niet}} [[mode]]",
+    "da": "Tilstand !{{er|er ikke}} [[mode]]",
+    "de": "Modus !{{ist|ist nicht}} [[mode]]",
+    "es": "El modo !{{es|no es}} [[mode]]",
+    "fr": "Le mode !{{est|n'est pas}} [[mode]]",
+    "it": "La modalità !{{è|non è}} [[mode]]",
+    "no": "Modus !{{er|er ikke}} [[mode]]",
+    "sv": "Läge !{{är|är inte}} [[mode]]",
+    "pl": "Tryb !{{jest|nie jest}} [[mode]]",
+    "ru": "Режим !{{равен|не равен}} [[mode]]",
+    "ko": "모드가 [[mode]] !{{임|아님}}"
+  },
+  "args": [
+    {
+      "name": "mode",
+      "title": {
+        "en": "Mode",
+        "nl": "Modus",
+        "da": "Tilstand",
+        "de": "Modus",
+        "es": "Modo",
+        "fr": "Mode",
+        "it": "Modalità",
+        "no": "Modus",
+        "sv": "Läge",
+        "pl": "Tryb",
+        "ru": "Режим",
+        "ko": "모드"
+      },
+      "type": "autocomplete"
+    }
+  ],
+  "platforms": ["local"]
+}

--- a/.homeycompose/drivers/flow/conditions/xiaomiVerticalAngleEquals.json
+++ b/.homeycompose/drivers/flow/conditions/xiaomiVerticalAngleEquals.json
@@ -1,0 +1,53 @@
+{
+  "id": "xiaomiVerticalAngleEquals",
+  "$filter": "capabilities=fan_xiaomi_vertical_angle",
+  "title": {
+    "en": "Vertical angle !{{is|is not}}",
+    "nl": "Verticale hoek !{{is|is niet}}",
+    "da": "Lodret vinkel !{{er|er ikke}}",
+    "de": "Vertikaler Winkel !{{ist|ist nicht}}",
+    "es": "El ángulo vertical !{{es|no es}}",
+    "fr": "L'angle vertical !{{est|n'est pas}}",
+    "it": "L'angolo verticale !{{è|non è}}",
+    "no": "Vertikal vinkel !{{er|er ikke}}",
+    "sv": "Vertikal vinkel !{{är|är inte}}",
+    "pl": "Kąt pionowy !{{jest|nie jest}}",
+    "ru": "Вертикальный угол !{{равен|не равен}}",
+    "ko": "수직 각도가 !{{임|아님}}"
+  },
+  "titleFormatted": {
+    "en": "Vertical angle !{{is|is not}} [[angle]]",
+    "nl": "Verticale hoek !{{is|is niet}} [[angle]]",
+    "da": "Lodret vinkel !{{er|er ikke}} [[angle]]",
+    "de": "Vertikaler Winkel !{{ist|ist nicht}} [[angle]]",
+    "es": "El ángulo vertical !{{es|no es}} [[angle]]",
+    "fr": "L'angle vertical !{{est|n'est pas}} [[angle]]",
+    "it": "L'angolo verticale !{{è|non è}} [[angle]]",
+    "no": "Vertikal vinkel !{{er|er ikke}} [[angle]]",
+    "sv": "Vertikal vinkel !{{är|är inte}} [[angle]]",
+    "pl": "Kąt pionowy !{{jest|nie jest}} [[angle]]",
+    "ru": "Вертикальный угол !{{равен|не равен}} [[angle]]",
+    "ko": "수직 각도가 [[angle]] !{{임|아님}}"
+  },
+  "args": [
+    {
+      "name": "angle",
+      "title": {
+        "en": "Angle",
+        "nl": "Hoek",
+        "da": "Vinkel",
+        "de": "Winkel",
+        "es": "Ángulo",
+        "fr": "Angle",
+        "it": "Angolo",
+        "no": "Vinkel",
+        "sv": "Vinkel",
+        "pl": "Kąt",
+        "ru": "Угол",
+        "ko": "각도"
+      },
+      "type": "autocomplete"
+    }
+  ],
+  "platforms": ["local"]
+}

--- a/.homeycompose/drivers/flow/conditions/xiaomiVerticalSwingIsOn.json
+++ b/.homeycompose/drivers/flow/conditions/xiaomiVerticalSwingIsOn.json
@@ -2,7 +2,7 @@
   "id": "xiaomiVerticalSwingIsOn",
   "$filter": "capabilities=fan_xiaomi_vertical_swing",
   "title": {
-    "en": "Vertical Swing is !{{on|off}}",
+    "en": "Vertical swing is !{{on|off}}",
     "nl": "Verticale oscillatie is !{{aan|uit}}",
     "da": "Lodret oscillation er !{{tændt|slukket}}",
     "de": "Vertikale Oszillation ist !{{an|aus}}",

--- a/.homeycompose/drivers/flow/triggers/xiaomiFanLevelChanged.json
+++ b/.homeycompose/drivers/flow/triggers/xiaomiFanLevelChanged.json
@@ -1,0 +1,59 @@
+{
+  "id": "xiaomiFanLevelChanged",
+  "$filter": "capabilities=fan_xiaomi_fanlevel",
+  "title": {
+    "en": "Fan level changed",
+    "nl": "Ventilatorniveau gewijzigd",
+    "da": "Ventilatorniveau ændret",
+    "de": "Ventilatorstufe geändert",
+    "es": "Nivel del ventilador cambiado",
+    "fr": "Niveau du ventilateur modifié",
+    "it": "Livello del ventilatore cambiato",
+    "no": "Viftenivå endret",
+    "sv": "Fläktnivå ändrad",
+    "pl": "Poziom wentylatora zmieniony",
+    "ru": "Уровень вентилятора изменился",
+    "ko": "팬 레벨 변경됨"
+  },
+  "tokens": [
+    {
+      "name": "new_level",
+      "type": "number",
+      "title": {
+        "en": "new level",
+        "nl": "nieuw niveau",
+        "da": "nyt niveau",
+        "de": "neue Stufe",
+        "es": "nuevo nivel",
+        "fr": "nouveau niveau",
+        "it": "nuovo livello",
+        "no": "nytt nivå",
+        "sv": "ny nivå",
+        "pl": "nowy poziom",
+        "ru": "новый уровень",
+        "ko": "새 레벨"
+      },
+      "example": 3
+    },
+    {
+      "name": "previous_level",
+      "type": "number",
+      "title": {
+        "en": "previous level",
+        "nl": "vorig niveau",
+        "da": "forrige niveau",
+        "de": "vorherige Stufe",
+        "es": "nivel anterior",
+        "fr": "niveau précédent",
+        "it": "livello precedente",
+        "no": "forrige nivå",
+        "sv": "föregående nivå",
+        "pl": "poprzedni poziom",
+        "ru": "предыдущий уровень",
+        "ko": "이전 레벨"
+      },
+      "example": 2
+    }
+  ],
+  "platforms": ["local"]
+}

--- a/.homeycompose/drivers/flow/triggers/xiaomiHorizontalAngleChanged.json
+++ b/.homeycompose/drivers/flow/triggers/xiaomiHorizontalAngleChanged.json
@@ -18,41 +18,41 @@
   "tokens": [
     {
       "name": "new_angle",
-      "type": "string",
+      "type": "number",
       "title": {
-        "en": "new angle",
-        "nl": "nieuwe hoek",
-        "da": "ny vinkel",
-        "de": "neuer Winkel",
-        "es": "nuevo ángulo",
-        "fr": "nouvel angle",
-        "it": "nuovo angolo",
-        "no": "ny vinkel",
-        "sv": "ny vinkel",
-        "pl": "nowy kąt",
-        "ru": "новый угол",
-        "ko": "새 각도"
+        "en": "new angle (°)",
+        "nl": "nieuwe hoek (°)",
+        "da": "ny vinkel (°)",
+        "de": "neuer Winkel (°)",
+        "es": "nuevo ángulo (°)",
+        "fr": "nouvel angle (°)",
+        "it": "nuovo angolo (°)",
+        "no": "ny vinkel (°)",
+        "sv": "ny vinkel (°)",
+        "pl": "nowy kąt (°)",
+        "ru": "новый угол (°)",
+        "ko": "새 각도 (°)"
       },
-      "example": "90°"
+      "example": 90
     },
     {
       "name": "previous_angle",
-      "type": "string",
+      "type": "number",
       "title": {
-        "en": "previous angle",
-        "nl": "vorige hoek",
-        "da": "forrige vinkel",
-        "de": "vorheriger Winkel",
-        "es": "ángulo anterior",
-        "fr": "angle précédent",
-        "it": "angolo precedente",
-        "no": "forrige vinkel",
-        "sv": "föregående vinkel",
-        "pl": "poprzedni kąt",
-        "ru": "предыдущий угол",
-        "ko": "이전 각도"
+        "en": "previous angle (°)",
+        "nl": "vorige hoek (°)",
+        "da": "forrige vinkel (°)",
+        "de": "vorheriger Winkel (°)",
+        "es": "ángulo anterior (°)",
+        "fr": "angle précédent (°)",
+        "it": "angolo precedente (°)",
+        "no": "forrige vinkel (°)",
+        "sv": "föregående vinkel (°)",
+        "pl": "poprzedni kąt (°)",
+        "ru": "предыдущий угол (°)",
+        "ko": "이전 각도 (°)"
       },
-      "example": "60°"
+      "example": 60
     }
   ],
   "platforms": ["local"]

--- a/.homeycompose/drivers/flow/triggers/xiaomiHorizontalAngleChanged.json
+++ b/.homeycompose/drivers/flow/triggers/xiaomiHorizontalAngleChanged.json
@@ -1,0 +1,59 @@
+{
+  "id": "xiaomiHorizontalAngleChanged",
+  "$filter": "capabilities=fan_xiaomi_horizontal_angle",
+  "title": {
+    "en": "Horizontal swing angle changed",
+    "nl": "Horizontale draaihoek gewijzigd",
+    "da": "Vandret svingvinkel ændret",
+    "de": "Horizontaler Schwenkwinkel geändert",
+    "es": "Ángulo de giro horizontal cambiado",
+    "fr": "Angle de balancement horizontal modifié",
+    "it": "Angolo di oscillazione orizzontale cambiato",
+    "no": "Horisontal svingvinkel endret",
+    "sv": "Horisontell svängvinkel ändrad",
+    "pl": "Poziomy kąt huśtania zmieniony",
+    "ru": "Угол горизонтального поворота изменился",
+    "ko": "수평 스윙 각도 변경됨"
+  },
+  "tokens": [
+    {
+      "name": "new_angle",
+      "type": "string",
+      "title": {
+        "en": "new angle",
+        "nl": "nieuwe hoek",
+        "da": "ny vinkel",
+        "de": "neuer Winkel",
+        "es": "nuevo ángulo",
+        "fr": "nouvel angle",
+        "it": "nuovo angolo",
+        "no": "ny vinkel",
+        "sv": "ny vinkel",
+        "pl": "nowy kąt",
+        "ru": "новый угол",
+        "ko": "새 각도"
+      },
+      "example": "90°"
+    },
+    {
+      "name": "previous_angle",
+      "type": "string",
+      "title": {
+        "en": "previous angle",
+        "nl": "vorige hoek",
+        "da": "forrige vinkel",
+        "de": "vorheriger Winkel",
+        "es": "ángulo anterior",
+        "fr": "angle précédent",
+        "it": "angolo precedente",
+        "no": "forrige vinkel",
+        "sv": "föregående vinkel",
+        "pl": "poprzedni kąt",
+        "ru": "предыдущий угол",
+        "ko": "이전 각도"
+      },
+      "example": "60°"
+    }
+  ],
+  "platforms": ["local"]
+}

--- a/.homeycompose/drivers/flow/triggers/xiaomiHorizontalSwingTurnedOff.json
+++ b/.homeycompose/drivers/flow/triggers/xiaomiHorizontalSwingTurnedOff.json
@@ -2,7 +2,7 @@
   "id": "xiaomiHorizontalSwingTurnedOff",
   "$filter": "capabilities=fan_xiaomi_horizontal_swing",
   "title": {
-    "en": "Horizontal Swing turned off",
+    "en": "Horizontal swing turned off",
     "nl": "Horizontale oscillatie uitgeschakeld",
     "da": "Vandret oscillation slukket",
     "de": "Horizontale Oszillation ausgeschaltet",

--- a/.homeycompose/drivers/flow/triggers/xiaomiHorizontalSwingTurnedOn.json
+++ b/.homeycompose/drivers/flow/triggers/xiaomiHorizontalSwingTurnedOn.json
@@ -2,7 +2,7 @@
   "id": "xiaomiHorizontalSwingTurnedOn",
   "$filter": "capabilities=fan_xiaomi_horizontal_swing",
   "title": {
-    "en": "Horizontal Swing turned on",
+    "en": "Horizontal swing turned on",
     "nl": "Horizontale oscillatie ingeschakeld",
     "da": "Vandret oscillation tændt",
     "de": "Horizontale Oszillation eingeschaltet",

--- a/.homeycompose/drivers/flow/triggers/xiaomiModeChanged.json
+++ b/.homeycompose/drivers/flow/triggers/xiaomiModeChanged.json
@@ -1,0 +1,59 @@
+{
+  "id": "xiaomiModeChanged",
+  "$filter": "capabilities=fan_xiaomi_mode",
+  "title": {
+    "en": "Mode has changed",
+    "nl": "Modus gewijzigd",
+    "de": "Modus hat sich geändert",
+    "da": "Tilstand er ændret",
+    "es": "El modo ha cambiado",
+    "fr": "Le mode a changé",
+    "it": "La modalità è cambiata",
+    "no": "Modus er endret",
+    "sv": "Läget har ändrats",
+    "pl": "Tryb został zmieniony",
+    "ru": "Режим изменился",
+    "ko": "모드가 변경되었습니다"
+  },
+  "tokens": [
+    {
+      "name": "new_mode",
+      "type": "string",
+      "title": {
+        "en": "new mode",
+        "nl": "nieuwe modus",
+        "de": "neue modus",
+        "da": "ny tilstand",
+        "es": "nuevo modo",
+        "fr": "nouveau mode",
+        "it": "nuova modalità",
+        "no": "ny modus",
+        "sv": "nytt läge",
+        "pl": "nowy tryb",
+        "ru": "новый режим",
+        "ko": "새로운 모드"
+      },
+      "example": "Regular Fan"
+    },
+    {
+      "name": "previous_mode",
+      "type": "string",
+      "title": {
+        "en": "previous mode",
+        "nl": "vorige modus",
+        "de": "bisherige modus",
+        "da": "forrige tilstand",
+        "es": "modo anterior",
+        "fr": "mode précédent",
+        "it": "modalità precedente",
+        "no": "forrige modus",
+        "sv": "föregående läge",
+        "pl": "poprzedni tryb",
+        "ru": "предыдущий режим",
+        "ko": "이전 모드"
+      },
+      "example": "Natural Wind"
+    }
+  ],
+  "platforms": ["local"]
+}

--- a/.homeycompose/drivers/flow/triggers/xiaomiVerticalAngleChanged.json
+++ b/.homeycompose/drivers/flow/triggers/xiaomiVerticalAngleChanged.json
@@ -18,41 +18,41 @@
   "tokens": [
     {
       "name": "new_angle",
-      "type": "string",
+      "type": "number",
       "title": {
-        "en": "new angle",
-        "nl": "nieuwe hoek",
-        "da": "ny vinkel",
-        "de": "neuer Winkel",
-        "es": "nuevo ángulo",
-        "fr": "nouvel angle",
-        "it": "nuovo angolo",
-        "no": "ny vinkel",
-        "sv": "ny vinkel",
-        "pl": "nowy kąt",
-        "ru": "новый угол",
-        "ko": "새 각도"
+        "en": "new angle (°)",
+        "nl": "nieuwe hoek (°)",
+        "da": "ny vinkel (°)",
+        "de": "neuer Winkel (°)",
+        "es": "nuevo ángulo (°)",
+        "fr": "nouvel angle (°)",
+        "it": "nuovo angolo (°)",
+        "no": "ny vinkel (°)",
+        "sv": "ny vinkel (°)",
+        "pl": "nowy kąt (°)",
+        "ru": "новый угол (°)",
+        "ko": "새 각도 (°)"
       },
-      "example": "90°"
+      "example": 90
     },
     {
       "name": "previous_angle",
-      "type": "string",
+      "type": "number",
       "title": {
-        "en": "previous angle",
-        "nl": "vorige hoek",
-        "da": "forrige vinkel",
-        "de": "vorheriger Winkel",
-        "es": "ángulo anterior",
-        "fr": "angle précédent",
-        "it": "angolo precedente",
-        "no": "forrige vinkel",
-        "sv": "föregående vinkel",
-        "pl": "poprzedni kąt",
-        "ru": "предыдущий угол",
-        "ko": "이전 각도"
+        "en": "previous angle (°)",
+        "nl": "vorige hoek (°)",
+        "da": "forrige vinkel (°)",
+        "de": "vorheriger Winkel (°)",
+        "es": "ángulo anterior (°)",
+        "fr": "angle précédent (°)",
+        "it": "angolo precedente (°)",
+        "no": "forrige vinkel (°)",
+        "sv": "föregående vinkel (°)",
+        "pl": "poprzedni kąt (°)",
+        "ru": "предыдущий угол (°)",
+        "ko": "이전 각도 (°)"
       },
-      "example": "60°"
+      "example": 60
     }
   ],
   "platforms": ["local"]

--- a/.homeycompose/drivers/flow/triggers/xiaomiVerticalAngleChanged.json
+++ b/.homeycompose/drivers/flow/triggers/xiaomiVerticalAngleChanged.json
@@ -1,0 +1,59 @@
+{
+  "id": "xiaomiVerticalAngleChanged",
+  "$filter": "capabilities=fan_xiaomi_vertical_angle",
+  "title": {
+    "en": "Vertical swing angle changed",
+    "nl": "Verticale draaihoek gewijzigd",
+    "da": "Lodret svingvinkel ændret",
+    "de": "Vertikaler Schwenkwinkel geändert",
+    "es": "Ángulo de giro vertical cambiado",
+    "fr": "Angle de balancement vertical modifié",
+    "it": "Angolo di oscillazione verticale cambiato",
+    "no": "Vertikal svingvinkel endret",
+    "sv": "Vertikal svängvinkel ändrad",
+    "pl": "Pionowy kąt huśtania zmieniony",
+    "ru": "Угол вертикального поворота изменился",
+    "ko": "수직 스윙 각도 변경됨"
+  },
+  "tokens": [
+    {
+      "name": "new_angle",
+      "type": "string",
+      "title": {
+        "en": "new angle",
+        "nl": "nieuwe hoek",
+        "da": "ny vinkel",
+        "de": "neuer Winkel",
+        "es": "nuevo ángulo",
+        "fr": "nouvel angle",
+        "it": "nuovo angolo",
+        "no": "ny vinkel",
+        "sv": "ny vinkel",
+        "pl": "nowy kąt",
+        "ru": "новый угол",
+        "ko": "새 각도"
+      },
+      "example": "90°"
+    },
+    {
+      "name": "previous_angle",
+      "type": "string",
+      "title": {
+        "en": "previous angle",
+        "nl": "vorige hoek",
+        "da": "forrige vinkel",
+        "de": "vorheriger Winkel",
+        "es": "ángulo anterior",
+        "fr": "angle précédent",
+        "it": "angolo precedente",
+        "no": "forrige vinkel",
+        "sv": "föregående vinkel",
+        "pl": "poprzedni kąt",
+        "ru": "предыдущий угол",
+        "ko": "이전 각도"
+      },
+      "example": "60°"
+    }
+  ],
+  "platforms": ["local"]
+}

--- a/.homeycompose/drivers/flow/triggers/xiaomiVerticalSwingTurnedOff.json
+++ b/.homeycompose/drivers/flow/triggers/xiaomiVerticalSwingTurnedOff.json
@@ -2,7 +2,7 @@
   "id": "xiaomiVerticalSwingTurnedOff",
   "$filter": "capabilities=fan_xiaomi_vertical_swing",
   "title": {
-    "en": "Vertical Swing turned off",
+    "en": "Vertical swing turned off",
     "nl": "Verticale oscillatie uitgeschakeld",
     "da": "Lodret oscillation slukket",
     "de": "Vertikale Oszillation ausgeschaltet",

--- a/.homeycompose/drivers/flow/triggers/xiaomiVerticalSwingTurnedOn.json
+++ b/.homeycompose/drivers/flow/triggers/xiaomiVerticalSwingTurnedOn.json
@@ -2,7 +2,7 @@
   "id": "xiaomiVerticalSwingTurnedOn",
   "$filter": "capabilities=fan_xiaomi_vertical_swing",
   "title": {
-    "en": "Vertical Swing turned on",
+    "en": "Vertical swing turned on",
     "nl": "Verticale oscillatie ingeschakeld",
     "da": "Lodret oscillation tændt",
     "de": "Vertikale Oszillation eingeschaltet",

--- a/drivers/fan_xiaomi_advanced/device.js
+++ b/drivers/fan_xiaomi_advanced/device.js
@@ -25,7 +25,7 @@ class AdvancedXiaomiFanMiotDevice extends Device {
             await engine.applyCapabilityOptions(this, this.descriptor);
 
             // FLOW TRIGGER CARDS
-            this.homey.flow.getDeviceTriggerCard('triggerModeChanged');
+            this.homey.flow.getDeviceTriggerCard('xiaomiModeChanged');
 
             // LISTENERS FOR UPDATING CAPABILITIES
             engine.registerListeners(this, this.descriptor);
@@ -46,15 +46,7 @@ class AdvancedXiaomiFanMiotDevice extends Device {
 
         const descriptor = this.getDescriptor();
 
-        if (changedKeys.includes('led')) {
-            await engine.writeSetting(this, descriptor, 'light', 'light', newSettings.led);
-        }
-        if (changedKeys.includes('buzzer')) {
-            await engine.writeSetting(this, descriptor, 'buzzer', 'buzzer', newSettings.buzzer);
-        }
-        if (changedKeys.includes('childLock')) {
-            await engine.writeSetting(this, descriptor, 'child_lock', 'child_lock', newSettings.childLock);
-        }
+        await engine.writeChangedSettings(this, descriptor, newSettings, changedKeys);
 
         return Promise.resolve(true);
     }

--- a/drivers/fan_xiaomi_advanced/device.js
+++ b/drivers/fan_xiaomi_advanced/device.js
@@ -54,12 +54,10 @@ class AdvancedXiaomiFanMiotDevice extends Device {
     async retrieveDeviceData() {
         try {
             const descriptor = this.getDescriptor();
-            const result = await this.miio.call('get_properties', engine.buildGetProperties(descriptor), { retries: 1 });
+            await engine.poll(this, descriptor);
             if (!this.getAvailable()) {
                 await this.setAvailable();
             }
-
-            await engine.pollAndUpdate(this, descriptor, result);
         } catch (error) {
             this.homey.clearInterval(this.pollingInterval);
 

--- a/drivers/fan_xiaomi_advanced/driver.flow.compose.json
+++ b/drivers/fan_xiaomi_advanced/driver.flow.compose.json
@@ -1,15 +1,24 @@
 {
   "triggers": [
+    { "$extends": ["xiaomiFanLevelChanged"] },
+    { "$extends": ["xiaomiModeChanged"] },
     { "$extends": ["xiaomiHorizontalSwingTurnedOn"] },
     { "$extends": ["xiaomiHorizontalSwingTurnedOff"] },
     { "$extends": ["xiaomiVerticalSwingTurnedOn"] },
-    { "$extends": ["xiaomiVerticalSwingTurnedOff"] }
+    { "$extends": ["xiaomiVerticalSwingTurnedOff"] },
+    { "$extends": ["xiaomiHorizontalAngleChanged"] },
+    { "$extends": ["xiaomiVerticalAngleChanged"] }
   ],
   "conditions": [
     { "$extends": ["xiaomiHorizontalSwingIsOn"] },
-    { "$extends": ["xiaomiVerticalSwingIsOn"] }
+    { "$extends": ["xiaomiVerticalSwingIsOn"] },
+    { "$extends": ["xiaomiModeEquals"] },
+    { "$extends": ["xiaomiFanLevelEquals"] },
+    { "$extends": ["xiaomiHorizontalAngleEquals"] },
+    { "$extends": ["xiaomiVerticalAngleEquals"] }
   ],
   "actions": [
+    { "$extends": ["xiaomiFanLevelSet"] },
     { "$extends": ["xiaomiFanMode"] },
     { "$extends": ["xiaomiHorizontalSwingOn"] },
     { "$extends": ["xiaomiHorizontalSwingOff"] },

--- a/drivers/fan_xiaomi_advanced/driver.flow.compose.json
+++ b/drivers/fan_xiaomi_advanced/driver.flow.compose.json
@@ -18,7 +18,7 @@
     { "$extends": ["xiaomiVerticalAngleEquals"] }
   ],
   "actions": [
-    { "$extends": ["xiaomiFanLevelSet"] },
+    { "$extends": ["xiaomiSetFanLevel"] },
     { "$extends": ["xiaomiFanMode"] },
     { "$extends": ["xiaomiHorizontalSwingOn"] },
     { "$extends": ["xiaomiHorizontalSwingOff"] },

--- a/drivers/fan_xiaomi_advanced/driver.js
+++ b/drivers/fan_xiaomi_advanced/driver.js
@@ -14,6 +14,11 @@ class AdvancedXiaomiFanMiotDriver extends Driver {
     engine.registerFlowCards(this);
   }
 
+  // Pairing hook: create the device with the capabilities its model supports.
+  getPairingCapabilities(model) {
+    return engine.desiredCapabilities(engine.resolve(model));
+  }
+
 }
 
 module.exports = AdvancedXiaomiFanMiotDriver;

--- a/drivers/wifi_driver.js
+++ b/drivers/wifi_driver.js
@@ -21,6 +21,10 @@ class MiHomeWifiDriver extends Homey.Driver {
         const name = await this.util.getFriendlyNameWiFi(model) || 'Unknown model';
         const device_name = name + ' ('+ model +')';
 
+        // Optional hook: a driver may return a model-specific capability list to create the device with.
+        // When omitted (undefined), the device keeps the capabilities declared in its driver.compose.json.
+        const capabilities = this.getPairingCapabilities?.(model);
+
         deviceObject = {
           name: device_name,
           data: {
@@ -33,7 +37,8 @@ class MiHomeWifiDriver extends Homey.Driver {
           },
           store: {
             model: model
-          }
+          },
+          ...(capabilities ? { capabilities } : {})
         }
         return Promise.resolve(deviceObject);
       } catch (error) {

--- a/lib/fans-xiaomi/engine.js
+++ b/lib/fans-xiaomi/engine.js
@@ -233,6 +233,7 @@ const registerFlowCards = (driver) => {
 
 module.exports = {
     resolve,
+    desiredCapabilities,
     syncCapabilities,
     applyCapabilityOptions,
     registerListeners,

--- a/lib/fans-xiaomi/engine.js
+++ b/lib/fans-xiaomi/engine.js
@@ -1,8 +1,11 @@
 'use strict';
 
-const { WRITERS, READ_DIDS, FLOW, READERS, SETTINGS } = require('./features.js');
+const { WRITERS, READ_DIDS, FLOW, READERS, SETTINGS, fanLevelOptions } = require('./features.js');
 const { MODE_LABELS } = require('./translations.js');
 const { MODELS, DEFAULT } = require('./models.js');
+
+const IMMEDIATE_POLL_STATE = Symbol('fan_xiaomi_immediate_poll_state');
+const LAST_TRIGGER_VALUES = Symbol('fan_xiaomi_last_trigger_values');
 
 /**
  * Runtime engine for the fan_xiaomi_advanced driver (xiaomi.fan.* only). Drives a
@@ -10,12 +13,10 @@ const { MODELS, DEFAULT } = require('./models.js');
  * delegate here. Uses custom fan_xiaomi_* capabilities for every swing control.
  */
 
-const DEFAULT_NORMALIZE = { zeroIndexing: false };
-
 /** Resolve a model id (incl. aliases) to its descriptor, or the generic default. */
 const resolve = (model) => {
     const desc = MODELS[model] ?? DEFAULT;
-    return { ...desc, normalize: { ...DEFAULT_NORMALIZE, ...(desc.normalize || {}) } };
+    return { ...desc };
 };
 
 /** Capabilities a descriptor should expose (derived from its declared props). */
@@ -41,6 +42,12 @@ const applyCapabilityOptions = async (device, desc) => {
     if (desc.modes && device.hasCapability('fan_xiaomi_mode')) {
         await device.setCapabilityOptions('fan_xiaomi_mode', {
             values: desc.modes.map((v) => ({ id: String(v), title: MODE_LABELS[v] ?? String(v) }))
+        });
+    }
+
+    if (desc.fanLevels && device.hasCapability('fan_xiaomi_fanlevel')) {
+        await device.setCapabilityOptions('fan_xiaomi_fanlevel', {
+            values: fanLevelOptions(desc).map((option) => ({ id: option.id, title: option.name }))
         });
     }
 
@@ -76,7 +83,12 @@ const registerListeners = (device, desc) => {
         const prop = desc.props[writer.propKey];
         device.registerCapabilityListener(writer.cap, async (value) => {
             try {
-                return await writeProperty(device, prop, writer.did, writer.encode(value, desc.normalize));
+                const writeResult = await writeProperty(device, prop, writer.did, writer.encode(value, desc));
+                // Confirm state in the background so listener completion is not delayed.
+                immediatePollAndUpdate(device, desc).catch((error) => {
+                    device.error(error);
+                });
+                return writeResult;
             } catch (error) {
                 device.error(error);
                 return Promise.reject(error);
@@ -89,29 +101,66 @@ const registerListeners = (device, desc) => {
 const buildGetProperties = (desc) =>
     READ_DIDS.filter((did) => desc.props[did] !== undefined).map((did) => ({ did, siid: desc.props[did].siid, piid: desc.props[did].piid }));
 
+/** Run one on-demand get_properties cycle and pass it through normal update+trigger logic. */
+const immediatePollAndUpdate = async (device, desc) => {
+    if (!device.miio) return;
+
+    const state = device[IMMEDIATE_POLL_STATE] || { inFlight: false, queued: false };
+    device[IMMEDIATE_POLL_STATE] = state;
+
+    if (state.inFlight) {
+        state.queued = true;
+        return;
+    }
+
+    state.inFlight = true;
+    try {
+        do {
+            state.queued = false;
+            try {
+                const result = await device.miio.call('get_properties', buildGetProperties(desc), { retries: 1 });
+                await pollAndUpdate(device, desc, result);
+            } catch (error) {
+                device.error(error);
+            }
+        } while (state.queued);
+    } finally {
+        state.inFlight = false;
+    }
+};
+
 /** Decode a poll result into capability/setting updates and fire triggers, driven by READERS/SETTINGS. */
 const pollAndUpdate = async (device, desc, result) => {
     const get = (did) => result.find((obj) => obj.did === did);
+    const lastValues = device[LAST_TRIGGER_VALUES] || (device[LAST_TRIGGER_VALUES] = {});
 
     for (const reader of READERS) {
         if (!device.hasCapability(reader.cap)) continue;
         const obj = get(reader.did);
         if (obj === undefined) continue;
-        const value = reader.decode(obj.value, desc.normalize);
-        const previous = device.getCapabilityValue(reader.cap);
+        const value = reader.decode(obj.value, desc);
+        // Compare against the last value we actually observed from the device, not the capability value:
+        // when the change is requested from the app or a Flow, Homey optimistically sets the capability first,
+        // which would otherwise mask the transition here and stop the trigger from firing.
+        const previous = reader.cap in lastValues ? lastValues[reader.cap] : device.getCapabilityValue(reader.cap);
+        lastValues[reader.cap] = value;
         await device.updateCapabilityValue(reader.cap, value);
         if (reader.trigger && value !== previous) {
-            const { card, tokens } = reader.trigger(value, previous, desc);
-            await device.homey.flow
-                .getDeviceTriggerCard(card)
-                .trigger(device, tokens)
-                .catch((error) => {
-                    device.error(error);
-                });
+            const trigger = reader.trigger(value, previous, desc);
+            const cards = trigger.cards || [trigger.card];
+            for (const card of cards) {
+                await device.homey.flow
+                    .getDeviceTriggerCard(card)
+                    .trigger(device, trigger.tokens)
+                    .catch((error) => {
+                        device.error(error);
+                    });
+            }
         }
     }
 
     for (const setting of SETTINGS) {
+        if (!setting.active(desc.props)) continue;
         const obj = get(setting.did);
         if (obj !== undefined) await device.updateSettingValue(setting.setting, setting.decode(obj.value));
     }
@@ -142,6 +191,15 @@ const writeSetting = async (device, desc, propKey, did, value) => {
     const prop = desc.props[propKey];
     if (!prop) return;
     await device.miio.call('set_properties', [{ did, siid: prop.siid, piid: prop.piid, value }], { retries: 1 });
+};
+
+/** Write all changed device settings using declarative SETTINGS metadata. */
+const writeChangedSettings = async (device, desc, newSettings, changedKeys) => {
+    for (const setting of SETTINGS) {
+        if (!setting.active(desc.props)) continue;
+        if (!changedKeys.includes(setting.setting)) continue;
+        await writeSetting(device, desc, setting.propKey, setting.did, newSettings[setting.setting]);
+    }
 };
 
 /** Register all flow-card run listeners once, with the runtime feature guard. */
@@ -182,5 +240,6 @@ module.exports = {
     pollAndUpdate,
     rotateFanHead,
     writeSetting,
+    writeChangedSettings,
     registerFlowCards
 };

--- a/lib/fans-xiaomi/engine.js
+++ b/lib/fans-xiaomi/engine.js
@@ -40,26 +40,39 @@ const syncCapabilities = async (device, desc) => {
 
 /** Configure the enum options for the model's mode and angle capabilities. */
 const applyCapabilityOptions = async (device, desc) => {
-    if (desc.modes && device.hasCapability('fan_xiaomi_mode')) {
-        await device.setCapabilityOptions('fan_xiaomi_mode', {
+    // setCapabilityOptions is expensive, so skip it when the options are unchanged.
+    const setOptionsIfChanged = async (cap, options) => {
+        if (!device.hasCapability(cap)) return;
+        let current;
+        try {
+            current = device.getCapabilityOptions(cap);
+        } catch (error) {
+            current = undefined;
+        }
+        if (current && JSON.stringify(current.values) === JSON.stringify(options.values)) return;
+        await device.setCapabilityOptions(cap, options);
+    };
+
+    if (desc.modes) {
+        await setOptionsIfChanged('fan_xiaomi_mode', {
             values: desc.modes.map((v) => ({ id: String(v), title: MODE_LABELS[v] ?? String(v) }))
         });
     }
 
-    if (desc.fanLevels && device.hasCapability('fan_xiaomi_fanlevel')) {
-        await device.setCapabilityOptions('fan_xiaomi_fanlevel', {
+    if (desc.fanLevels) {
+        await setOptionsIfChanged('fan_xiaomi_fanlevel', {
             values: fanLevelOptions(desc).map((option) => ({ id: option.id, title: option.name }))
         });
     }
 
-    if (desc.horizontalAngles && device.hasCapability('fan_xiaomi_horizontal_angle')) {
-        await device.setCapabilityOptions('fan_xiaomi_horizontal_angle', {
+    if (desc.horizontalAngles) {
+        await setOptionsIfChanged('fan_xiaomi_horizontal_angle', {
             values: desc.horizontalAngles.map((angle) => ({ id: angle.toString(), title: `${angle}°` }))
         });
     }
 
-    if (desc.verticalAngles && device.hasCapability('fan_xiaomi_vertical_angle')) {
-        await device.setCapabilityOptions('fan_xiaomi_vertical_angle', {
+    if (desc.verticalAngles) {
+        await setOptionsIfChanged('fan_xiaomi_vertical_angle', {
             values: desc.verticalAngles.map((angle) => ({ id: angle.toString(), title: `${angle}°` }))
         });
     }
@@ -153,8 +166,9 @@ const pollAndUpdate = async (device, desc, result) => {
         if (!device.hasCapability(reader.cap)) continue;
         const obj = get(reader.did);
         if (obj === undefined) continue;
-        // Skip failed / invalid reads so they can't produce bogus capability values
-        // or tokens (NaN, "null°", unknown mode); only valid observations continue.
+        // Skip failed / invalid reads so they can't set bogus capability values
+        // or fire bad change triggers (a NaN speed, an out-of-range angle, an unknown mode);
+        // only valid observations continue.
         if (obj.code !== undefined && obj.code !== 0) continue;
         if (obj.value === null || obj.value === undefined) continue;
         if (reader.valid && !reader.valid(obj.value, desc)) continue;

--- a/lib/fans-xiaomi/engine.js
+++ b/lib/fans-xiaomi/engine.js
@@ -4,7 +4,8 @@ const { WRITERS, READ_DIDS, FLOW, READERS, SETTINGS, fanLevelOptions } = require
 const { MODE_LABELS } = require('./translations.js');
 const { MODELS, DEFAULT } = require('./models.js');
 
-const IMMEDIATE_POLL_STATE = Symbol('fan_xiaomi_immediate_poll_state');
+const POLL_QUEUE = Symbol('fan_xiaomi_poll_queue');
+const IMMEDIATE_PENDING = Symbol('fan_xiaomi_immediate_pending');
 const LAST_TRIGGER_VALUES = Symbol('fan_xiaomi_last_trigger_values');
 
 /**
@@ -101,32 +102,46 @@ const registerListeners = (device, desc) => {
 const buildGetProperties = (desc) =>
     READ_DIDS.filter((did) => desc.props[did] !== undefined).map((did) => ({ did, siid: desc.props[did].siid, piid: desc.props[did].piid }));
 
-/** Run one on-demand get_properties cycle and pass it through normal update+trigger logic. */
-const immediatePollAndUpdate = async (device, desc) => {
-    if (!device.miio) return;
+/** Run one get_properties cycle and pass the result through the normal update+trigger logic. */
+const runPollCycle = async (device, desc) => {
+    const result = await device.miio.call('get_properties', buildGetProperties(desc), { retries: 1 });
+    await pollAndUpdate(device, desc, result);
+    return result;
+};
 
-    const state = device[IMMEDIATE_POLL_STATE] || { inFlight: false, queued: false };
-    device[IMMEDIATE_POLL_STATE] = state;
+/**
+ * Append a poll cycle to the device's shared serial queue. Regular polls and
+ * on-demand (post-write) polls all go through here, so their get_properties
+ * responses can never interleave and an older response cannot overwrite newer
+ * state or emit out-of-order triggers.
+ */
+const enqueuePoll = (device, task) => {
+    const tail = device[POLL_QUEUE] || Promise.resolve();
+    const run = tail.then(() => task(), () => task());
+    device[POLL_QUEUE] = run.then(() => {}, () => {});
+    return run;
+};
 
-    if (state.inFlight) {
-        state.queued = true;
-        return;
-    }
+/** Regular poll cycle (from retrieveDeviceData), serialized on the shared queue. */
+const poll = (device, desc) => enqueuePoll(device, () => runPollCycle(device, desc));
 
-    state.inFlight = true;
-    try {
-        do {
-            state.queued = false;
-            try {
-                const result = await device.miio.call('get_properties', buildGetProperties(desc), { retries: 1 });
-                await pollAndUpdate(device, desc, result);
-            } catch (error) {
-                device.error(error);
-            }
-        } while (state.queued);
-    } finally {
-        state.inFlight = false;
-    }
+/**
+ * On-demand poll used to confirm state right after a write. Serialized on the
+ * same shared queue as the regular poll, and coalesced so a burst of writes
+ * enqueues at most one pending confirmation poll.
+ */
+const immediatePollAndUpdate = (device, desc) => {
+    if (!device.miio) return Promise.resolve();
+    if (device[IMMEDIATE_PENDING]) return device[IMMEDIATE_PENDING];
+
+    const pending = enqueuePoll(device, () => {
+        // Cleared once this poll starts running,
+        // so a write arriving mid-cycle can queue exactly one more confirmation poll.
+        device[IMMEDIATE_PENDING] = null;
+        return runPollCycle(device, desc);
+    });
+    device[IMMEDIATE_PENDING] = pending;
+    return pending;
 };
 
 /** Decode a poll result into capability/setting updates and fire triggers, driven by READERS/SETTINGS. */
@@ -138,14 +153,22 @@ const pollAndUpdate = async (device, desc, result) => {
         if (!device.hasCapability(reader.cap)) continue;
         const obj = get(reader.did);
         if (obj === undefined) continue;
+        // Skip failed / invalid reads so they can't produce bogus capability values
+        // or tokens (NaN, "null°", unknown mode); only valid observations continue.
+        if (obj.code !== undefined && obj.code !== 0) continue;
+        if (obj.value === null || obj.value === undefined) continue;
+        if (reader.valid && !reader.valid(obj.value, desc)) continue;
+
         const value = reader.decode(obj.value, desc);
-        // Compare against the last value we actually observed from the device, not the capability value:
-        // when the change is requested from the app or a Flow, Homey optimistically sets the capability first,
-        // which would otherwise mask the transition here and stop the trigger from firing.
-        const previous = reader.cap in lastValues ? lastValues[reader.cap] : device.getCapabilityValue(reader.cap);
+        // Seed the trigger cache on the first observation without firing,
+        // so an app restart / newly added capability can't emit a false change with a null-ish "previous".
+        // Compare against the last value observed from the device,
+        // not the capability value (which Homey sets optimistically on app/Flow writes).
+        const hadPrevious = reader.cap in lastValues;
+        const previous = lastValues[reader.cap];
         lastValues[reader.cap] = value;
         await device.updateCapabilityValue(reader.cap, value);
-        if (reader.trigger && value !== previous) {
+        if (reader.trigger && hadPrevious && value !== previous) {
             const trigger = reader.trigger(value, previous, desc);
             const cards = trigger.cards || [trigger.card];
             for (const card of cards) {
@@ -162,7 +185,10 @@ const pollAndUpdate = async (device, desc, result) => {
     for (const setting of SETTINGS) {
         if (!setting.active(desc.props)) continue;
         const obj = get(setting.did);
-        if (obj !== undefined) await device.updateSettingValue(setting.setting, setting.decode(obj.value));
+        if (obj === undefined) continue;
+        if (obj.code !== undefined && obj.code !== 0) continue;
+        if (obj.value === null || obj.value === undefined) continue;
+        await device.updateSettingValue(setting.setting, setting.decode(obj.value));
     }
 };
 
@@ -238,6 +264,7 @@ module.exports = {
     applyCapabilityOptions,
     registerListeners,
     buildGetProperties,
+    poll,
     pollAndUpdate,
     rotateFanHead,
     writeSetting,

--- a/lib/fans-xiaomi/engine.js
+++ b/lib/fans-xiaomi/engine.js
@@ -279,6 +279,7 @@ module.exports = {
     registerListeners,
     buildGetProperties,
     poll,
+    immediatePollAndUpdate,
     pollAndUpdate,
     rotateFanHead,
     writeSetting,

--- a/lib/fans-xiaomi/features.js
+++ b/lib/fans-xiaomi/features.js
@@ -5,6 +5,9 @@ const { MODE_LABELS } = require('./translations.js');
 /** Clamp a number into an inclusive range. */
 const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
 
+/** Whether a raw device value is one of the descriptor's allowed values. */
+const isAllowedValue = (list, raw) => Array.isArray(list) && list.map(Number).includes(Number(raw));
+
 const fanLevelDisplayOffset = (desc) => {
     const rawLevels = (desc.fanLevels || []).map((level) => Number(level)).filter((level) => Number.isFinite(level));
     return rawLevels.length > 0 && Math.min(...rawLevels) === 0 ? 1 : 0;
@@ -256,7 +259,11 @@ const FLOW = [
  * so adding a feature stays data-only on both the write and the read side.
  */
 const READERS = [
-    { cap: 'onoff', did: 'power', decode: (value) => value },
+    {
+        cap: 'onoff',
+        did: 'power',
+        decode: (value) => value
+    },
     {
         cap: 'fan_xiaomi_horizontal_swing',
         did: 'swing_h',
@@ -266,6 +273,7 @@ const READERS = [
     {
         cap: 'fan_xiaomi_fanlevel',
         did: 'fan_level',
+        valid: (value, desc) => isAllowedValue(desc.fanLevels, value),
         decode: (value, desc) => {
             const offset = fanLevelDisplayOffset(desc);
             return String(Number(value) + offset);
@@ -275,10 +283,16 @@ const READERS = [
     {
         cap: 'fan_xiaomi_horizontal_angle',
         did: 'swing_h_angle',
+        valid: (value, desc) => isAllowedValue(desc.horizontalAngles, value),
         decode: (value) => value.toString(),
         trigger: (value, previous) => ({ card: 'xiaomiHorizontalAngleChanged', tokens: { new_angle: `${value}°`, previous_angle: `${previous}°` } })
     },
-    { cap: 'fan_speed', did: 'fan_speed', decode: (value) => value / 100 },
+    {
+        cap: 'fan_speed',
+        did: 'fan_speed',
+        valid: (value) => Number.isFinite(Number(value)),
+        decode: (value) => value / 100
+    },
     {
         cap: 'fan_xiaomi_vertical_swing',
         did: 'swing_v',
@@ -288,12 +302,14 @@ const READERS = [
     {
         cap: 'fan_xiaomi_vertical_angle',
         did: 'swing_v_angle',
+        valid: (value, desc) => isAllowedValue(desc.verticalAngles, value),
         decode: (value) => value.toString(),
         trigger: (value, previous) => ({ card: 'xiaomiVerticalAngleChanged', tokens: { new_angle: `${value}°`, previous_angle: `${previous}°` } })
     },
     {
         cap: 'fan_xiaomi_mode',
         did: 'mode',
+        valid: (value, desc) => isAllowedValue(desc.modes, value),
         decode: (value) => value.toString(),
         trigger: (value, previous) => {
             const label = (v) => MODE_LABELS[v]?.en ?? String(v);

--- a/lib/fans-xiaomi/features.js
+++ b/lib/fans-xiaomi/features.js
@@ -5,6 +5,20 @@ const { MODE_LABELS } = require('./translations.js');
 /** Clamp a number into an inclusive range. */
 const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
 
+const fanLevelDisplayOffset = (desc) => {
+    const rawLevels = (desc.fanLevels || []).map((level) => Number(level)).filter((level) => Number.isFinite(level));
+    return rawLevels.length > 0 && Math.min(...rawLevels) === 0 ? 1 : 0;
+};
+
+const fanLevelOptions = (desc) => {
+    const levels = (desc.fanLevels || []).map((level) => Number(level)).filter((level) => Number.isFinite(level));
+    const offset = fanLevelDisplayOffset(desc);
+    return levels.map((level) => {
+        const capabilityValue = String(level + offset);
+        return { name: capabilityValue, id: capabilityValue };
+    });
+};
+
 /**
  * Single source of truth for the fan_xiaomi_advanced driver's capabilities and
  * flow cards. This driver uses custom capabilities for ALL swing controls (no
@@ -37,7 +51,10 @@ const WRITERS = [
         propKey: 'fan_level',
         did: 'fan_level',
         active: (props) => props.fan_level !== undefined,
-        encode: (value, normalize) => (normalize.zeroIndexing ? clamp(Number(value) - 1, 0, 3) : Number(value))
+        encode: (value, desc) => {
+            const offset = fanLevelDisplayOffset(desc);
+            return Number(value) - offset;
+        }
     },
     {
         cap: 'fan_xiaomi_horizontal_angle',
@@ -76,9 +93,6 @@ const WRITERS = [
     }
 ];
 
-/** Ordered did list used to derive get_properties (only those present in props). */
-const READ_DIDS = ['power', 'fan_level', 'mode', 'swing_h', 'swing_h_angle', 'fan_speed', 'light', 'buzzer', 'child_lock', 'swing_v', 'swing_v_angle'];
-
 /** Whether a model can rotate its head in `direction`, from its unified `rotate` block. */
 const canRotate = (desc, direction) => desc.rotate !== undefined && desc.rotate[direction] !== undefined;
 
@@ -100,6 +114,53 @@ const FLOW = [
             }
             return device.triggerCapabilityListener('fan_xiaomi_mode', args.mode.id);
         }
+    },
+    {
+        card: 'xiaomiFanLevelSet',
+        type: 'action',
+        requires: { cap: 'fan_xiaomi_fanlevel', label: 'fan level' },
+        autocomplete: {
+            arg: 'level',
+            options: (desc) => fanLevelOptions(desc)
+        },
+        run: (device, args) => device.triggerCapabilityListener('fan_xiaomi_fanlevel', args.level.id)
+    },
+    {
+        card: 'xiaomiModeEquals',
+        type: 'condition',
+        requires: { cap: 'fan_xiaomi_mode', label: 'mode' },
+        autocomplete: {
+            arg: 'mode',
+            options: (desc, homey) => {
+                const lang = homey.i18n.getLanguage();
+                return (desc.modes || []).map((v) => ({ name: MODE_LABELS[v]?.[lang] ?? MODE_LABELS[v]?.en ?? String(v), id: String(v) }));
+            }
+        },
+        run: (device, args) => String(device.getCapabilityValue('fan_xiaomi_mode')) === String(args.mode.id)
+    },
+    {
+        card: 'xiaomiFanLevelEquals',
+        type: 'condition',
+        requires: { cap: 'fan_xiaomi_fanlevel', label: 'fan level' },
+        autocomplete: {
+            arg: 'level',
+            options: (desc) => fanLevelOptions(desc)
+        },
+        run: (device, args) => String(device.getCapabilityValue('fan_xiaomi_fanlevel')) === String(args.level.id)
+    },
+    {
+        card: 'xiaomiHorizontalAngleEquals',
+        type: 'condition',
+        requires: { cap: 'fan_xiaomi_horizontal_angle', label: 'horizontal angle' },
+        autocomplete: { arg: 'angle', options: (desc) => (desc.horizontalAngles || []).map((a) => ({ name: `${a}°`, id: String(a) })) },
+        run: (device, args) => String(device.getCapabilityValue('fan_xiaomi_horizontal_angle')) === String(args.angle.id)
+    },
+    {
+        card: 'xiaomiVerticalAngleEquals',
+        type: 'condition',
+        requires: { cap: 'fan_xiaomi_vertical_angle', label: 'vertical angle' },
+        autocomplete: { arg: 'angle', options: (desc) => (desc.verticalAngles || []).map((a) => ({ name: `${a}°`, id: String(a) })) },
+        run: (device, args) => String(device.getCapabilityValue('fan_xiaomi_vertical_angle')) === String(args.angle.id)
     },
     {
         card: 'xiaomiHorizontalSwingIsOn',
@@ -202,8 +263,21 @@ const READERS = [
         decode: (value) => !!value,
         trigger: (value) => ({ card: value ? 'xiaomiHorizontalSwingTurnedOn' : 'xiaomiHorizontalSwingTurnedOff' })
     },
-    { cap: 'fan_xiaomi_fanlevel', did: 'fan_level', decode: (value, normalize) => (normalize.zeroIndexing ? +value + 1 : +value).toString() },
-    { cap: 'fan_xiaomi_horizontal_angle', did: 'swing_h_angle', decode: (value) => value.toString() },
+    {
+        cap: 'fan_xiaomi_fanlevel',
+        did: 'fan_level',
+        decode: (value, desc) => {
+            const offset = fanLevelDisplayOffset(desc);
+            return String(Number(value) + offset);
+        },
+        trigger: (value, previous) => ({ card: 'xiaomiFanLevelChanged', tokens: { new_level: Number(value), previous_level: Number(previous) } })
+    },
+    {
+        cap: 'fan_xiaomi_horizontal_angle',
+        did: 'swing_h_angle',
+        decode: (value) => value.toString(),
+        trigger: (value, previous) => ({ card: 'xiaomiHorizontalAngleChanged', tokens: { new_angle: `${value}°`, previous_angle: `${previous}°` } })
+    },
     { cap: 'fan_speed', did: 'fan_speed', decode: (value) => value / 100 },
     {
         cap: 'fan_xiaomi_vertical_swing',
@@ -211,23 +285,52 @@ const READERS = [
         decode: (value) => !!value,
         trigger: (value) => ({ card: value ? 'xiaomiVerticalSwingTurnedOn' : 'xiaomiVerticalSwingTurnedOff' })
     },
-    { cap: 'fan_xiaomi_vertical_angle', did: 'swing_v_angle', decode: (value) => value.toString() },
+    {
+        cap: 'fan_xiaomi_vertical_angle',
+        did: 'swing_v_angle',
+        decode: (value) => value.toString(),
+        trigger: (value, previous) => ({ card: 'xiaomiVerticalAngleChanged', tokens: { new_angle: `${value}°`, previous_angle: `${previous}°` } })
+    },
     {
         cap: 'fan_xiaomi_mode',
         did: 'mode',
         decode: (value) => value.toString(),
         trigger: (value, previous) => {
             const label = (v) => MODE_LABELS[v]?.en ?? String(v);
-            return { card: 'triggerModeChanged', tokens: { new_mode: label(value), previous_mode: label(previous) } };
+            return {
+                card: 'xiaomiModeChanged',
+                tokens: { new_mode: label(value), previous_mode: label(previous) }
+            };
         }
     }
 ];
 
 /** SETTINGS drive the poll path for device settings (led/buzzer/childLock), not capabilities. */
 const SETTINGS = [
-    { setting: 'led', did: 'light', decode: (value) => !!value },
-    { setting: 'buzzer', did: 'buzzer', decode: (value) => value },
-    { setting: 'childLock', did: 'child_lock', decode: (value) => value }
+    {
+        setting: 'led',
+        propKey: 'light',
+        did: 'light',
+        active: (props) => props.light !== undefined,
+        decode: (value) => !!value
+    },
+    {
+        setting: 'buzzer',
+        propKey: 'buzzer',
+        did: 'buzzer',
+        active: (props) => props.buzzer !== undefined,
+        decode: (value) => value
+    },
+    {
+        setting: 'childLock',
+        propKey: 'child_lock',
+        did: 'child_lock',
+        active: (props) => props.child_lock !== undefined,
+        decode: (value) => value
+    }
 ];
 
-module.exports = { WRITERS, READ_DIDS, FLOW, READERS, SETTINGS };
+/** Unique did list used for get_properties polling. */
+const READ_DIDS = [...new Set([...READERS.map((reader) => reader.did), ...SETTINGS.map((setting) => setting.did)])];
+
+module.exports = { WRITERS, READ_DIDS, FLOW, READERS, SETTINGS, fanLevelOptions };

--- a/lib/fans-xiaomi/features.js
+++ b/lib/fans-xiaomi/features.js
@@ -119,7 +119,7 @@ const FLOW = [
         }
     },
     {
-        card: 'xiaomiFanLevelSet',
+        card: 'xiaomiSetFanLevel',
         type: 'action',
         requires: { cap: 'fan_xiaomi_fanlevel', label: 'fan level' },
         autocomplete: {
@@ -254,9 +254,9 @@ const FLOW = [
 ];
 
 /**
- * READERS drive the poll/update path: each entry decodes one polled property into a
- * capability value and optionally fires a device trigger on change. Mirrors WRITERS
- * so adding a feature stays data-only on both the write and the read side.
+ * READERS drive the poll/update path: each entry optionally validates the raw value (`valid`),
+ * decodes it into a capability value, and optionally fires a device trigger on change.
+ * Mirrors WRITERS so adding a feature stays data-only on both the write and the read side.
  */
 const READERS = [
     {
@@ -285,7 +285,7 @@ const READERS = [
         did: 'swing_h_angle',
         valid: (value, desc) => isAllowedValue(desc.horizontalAngles, value),
         decode: (value) => value.toString(),
-        trigger: (value, previous) => ({ card: 'xiaomiHorizontalAngleChanged', tokens: { new_angle: `${value}°`, previous_angle: `${previous}°` } })
+        trigger: (value, previous) => ({ card: 'xiaomiHorizontalAngleChanged', tokens: { new_angle: Number(value), previous_angle: Number(previous) } })
     },
     {
         cap: 'fan_speed',
@@ -304,7 +304,7 @@ const READERS = [
         did: 'swing_v_angle',
         valid: (value, desc) => isAllowedValue(desc.verticalAngles, value),
         decode: (value) => value.toString(),
-        trigger: (value, previous) => ({ card: 'xiaomiVerticalAngleChanged', tokens: { new_angle: `${value}°`, previous_angle: `${previous}°` } })
+        trigger: (value, previous) => ({ card: 'xiaomiVerticalAngleChanged', tokens: { new_angle: Number(value), previous_angle: Number(previous) } })
     },
     {
         cap: 'fan_xiaomi_mode',

--- a/lib/fans-xiaomi/models.js
+++ b/lib/fans-xiaomi/models.js
@@ -11,10 +11,11 @@ const { MODE } = require('./constants.js');
  *
  * Each descriptor lists only what the model has (an absent field means "unsupported"):
  *   props             MIOT { siid, piid } per feature; each present prop switches on its capability (see WRITERS).
+ *   fanLevels         required when props.fan_level is set — raw MIOT Gear values (for example [1,2,3,4] or [0,1,2,3]).
+ *                     Keep this separate from `fan_speed` (Stepless Fan Level, typically range[1,100,1]).
  *   modes             required when props.mode is set — array of supported device values, e.g. [MODE.REGULAR, MODE.NATURAL].
  *   horizontalAngles  required when props.swing_h_angle is set — allowed swing_h angles.
  *   verticalAngles    required when props.swing_v_angle is set — allowed swing_v angles.
- *   normalize         optional — { zeroIndexing } value-encoding quirk (default false).
  *   rotate            optional — head-rotation map { via: 'action', siid, left, right, up?, down? }.
  *   fallback          DEFAULT-only — true on DEFAULT, unset on real models; tailors "unrecognized model" errors.
  *
@@ -23,7 +24,8 @@ const { MODE } = require('./constants.js');
  *      (the script pulls piids from the MIoT spec API). For a read-friendly overview see
  *      https://home.miot-spec.com/spec/<model-id> — though that page doesn't list piids.
  *   2. Add `const pXX = { ... }` using the fields above.
- *   3. Set `normalize` if the model zero-indexes gears.
+ *   3. Set `fanLevels` from the model's Gear Fan Level enum values exactly as reported by the device.
+ *      Do not use Stepless Fan Level ranges here; those map to `props.fan_speed`.
  *   4. Register it in MODELS under its model id. Alias spec-identical siblings to one shared
  *      descriptor (p76 -> p70) instead of duplicating. Never set `fallback` on a real model.
  *   5. If the model uses a value the shared enums don't list yet, also extend the matching
@@ -37,6 +39,7 @@ const { MODE } = require('./constants.js');
  */
 
 const p30 = {
+    fanLevels: [1, 2, 3, 4],
     modes: [MODE.REGULAR, MODE.NATURAL],
     horizontalAngles: [30, 60, 90, 120, 140],
     rotate: { via: 'action', siid: 2, left: 4, right: 5 },
@@ -54,6 +57,7 @@ const p30 = {
 };
 
 const p43 = {
+    fanLevels: [1, 2, 3, 4],
     modes: [MODE.REGULAR, MODE.NATURAL, MODE.SLEEP],
     horizontalAngles: [30, 60, 90],
     rotate: { via: 'action', siid: 2, left: 2, right: 3 },
@@ -71,6 +75,7 @@ const p43 = {
 };
 
 const p45 = {
+    fanLevels: [1, 2, 3, 4],
     modes: [MODE.REGULAR, MODE.NATURAL, MODE.SLEEP],
     horizontalAngles: [30, 60, 90, 120, 150],
     rotate: { via: 'action', siid: 2, left: 4, right: 5 },
@@ -88,6 +93,7 @@ const p45 = {
 };
 
 const p51 = {
+    fanLevels: [1, 2, 3, 4],
     modes: [MODE.REGULAR, MODE.NATURAL],
     horizontalAngles: [30, 60, 90, 120],
     rotate: { via: 'action', siid: 2, left: 4, right: 5 },
@@ -105,7 +111,7 @@ const p51 = {
 };
 
 const p70 = {
-    normalize: { zeroIndexing: true },
+    fanLevels: [0, 1, 2, 3],
     modes: [MODE.REGULAR, MODE.NATURAL],
     horizontalAngles: [30, 60, 90, 120],
     verticalAngles: [30, 60, 90, 100],
@@ -126,6 +132,7 @@ const p70 = {
 };
 
 const p85 = {
+    fanLevels: [1, 2, 3, 4],
     modes: [MODE.REGULAR, MODE.NATURAL],
     horizontalAngles: [30, 60, 90],
     rotate: { via: 'action', siid: 2, left: 6, right: 7 },
@@ -145,6 +152,7 @@ const p85 = {
 /* Fallback for unknown xiaomi.fan.* models: p70 property layout, generic modes. */
 const DEFAULT = {
     fallback: true,
+    fanLevels: [1, 2, 3, 4],
     modes: [MODE.REGULAR, MODE.NATURAL],
     horizontalAngles: [30, 60, 90],
     props: {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "com.xiaomi-miio",
   "version": "3.3.0",
   "main": "app.js",
-  "scripts": {},
+  "scripts": {
+    "test": "node --test"
+  },
   "devDependencies": {
     "@tsconfig/node12": "^12.1.5",
     "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",

--- a/test/fan-xiaomi.test.js
+++ b/test/fan-xiaomi.test.js
@@ -1,0 +1,259 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const engine = require('../lib/fans-xiaomi/engine.js');
+const { MODELS, DEFAULT } = require('../lib/fans-xiaomi/models.js');
+const { WRITERS, READERS, fanLevelOptions } = require('../lib/fans-xiaomi/features.js');
+
+const fanlevelWriter = WRITERS.find((w) => w.cap === 'fan_xiaomi_fanlevel');
+const fanlevelReader = READERS.find((r) => r.cap === 'fan_xiaomi_fanlevel');
+
+/**
+ * Minimal in-memory stand-in for a Homey device, enough to exercise the engine
+ * without the Homey runtime. Records capability values, options, settings and
+ * fired triggers so tests can assert on them.
+ */
+function createMockDevice({ capabilities = [], miioCall } = {}) {
+    const caps = new Set(capabilities);
+    const capabilityValues = {};
+    const capabilityOptions = {};
+    const settingValues = {};
+    const triggered = [];
+
+    return {
+        _capabilityValues: capabilityValues,
+        _capabilityOptions: capabilityOptions,
+        _settingValues: settingValues,
+        _triggered: triggered,
+        hasCapability: (cap) => caps.has(cap),
+        getCapabilityValue: (cap) => (cap in capabilityValues ? capabilityValues[cap] : null),
+        updateCapabilityValue: async (cap, value) => { capabilityValues[cap] = value; },
+        getCapabilityOptions: (cap) => {
+            if (!(cap in capabilityOptions)) throw new Error(`no options for ${cap}`);
+            return capabilityOptions[cap];
+        },
+        setCapabilityOptions: async (cap, options) => { capabilityOptions[cap] = options; },
+        addCapability: async (cap) => { caps.add(cap); },
+        removeCapability: async (cap) => { caps.delete(cap); },
+        updateSettingValue: async (setting, value) => { settingValues[setting] = value; },
+        error: () => {},
+        log: () => {},
+        homey: {
+            flow: {
+                getDeviceTriggerCard: (card) => ({
+                    trigger: async (_device, tokens) => { triggered.push({ card, tokens }); }
+                })
+            }
+        },
+        miio: miioCall ? { call: miioCall } : undefined
+    };
+}
+
+test('every model descriptor is structurally consistent', () => {
+    const descriptors = [...Object.entries(MODELS), ['DEFAULT', DEFAULT]];
+    for (const [id, desc] of descriptors) {
+        assert.ok(desc.props && typeof desc.props === 'object', `${id} declares props`);
+
+        // A property and its enum/range list must appear together.
+        assert.equal('fan_level' in desc.props, Array.isArray(desc.fanLevels), `${id}: fan_level ⇔ fanLevels`);
+        assert.equal('mode' in desc.props, Array.isArray(desc.modes), `${id}: mode ⇔ modes`);
+        assert.equal('swing_h_angle' in desc.props, Array.isArray(desc.horizontalAngles), `${id}: swing_h_angle ⇔ horizontalAngles`);
+        assert.equal('swing_v_angle' in desc.props, Array.isArray(desc.verticalAngles), `${id}: swing_v_angle ⇔ verticalAngles`);
+
+        if (desc.fanLevels) {
+            assert.ok(desc.fanLevels.length > 0, `${id}: fanLevels not empty`);
+            assert.ok(desc.fanLevels.every(Number.isFinite), `${id}: fanLevels are numbers`);
+        }
+        for (const list of ['modes', 'horizontalAngles', 'verticalAngles']) {
+            if (desc[list]) assert.ok(desc[list].every(Number.isFinite), `${id}: ${list} are numbers`);
+        }
+        // Every MIOT prop entry carries a numeric siid/piid.
+        for (const [key, prop] of Object.entries(desc.props)) {
+            assert.equal(typeof prop.siid, 'number', `${id}.${key}.siid`);
+            assert.equal(typeof prop.piid, 'number', `${id}.${key}.piid`);
+        }
+    }
+});
+
+test('unknown models resolve to the generic fallback descriptor', () => {
+    const desc = engine.resolve('xiaomi.fan.does-not-exist');
+    assert.equal(desc.fallback, true);
+    assert.ok(desc.props, 'fallback descriptor is usable');
+});
+
+test('resolve maps the p69/p76 aliases onto the same descriptor as p70', () => {
+    const p70 = engine.resolve('xiaomi.fan.p70');
+    assert.deepEqual(engine.resolve('xiaomi.fan.p69').fanLevels, p70.fanLevels);
+    assert.deepEqual(engine.resolve('xiaomi.fan.p76').fanLevels, p70.fanLevels);
+});
+
+test('fan levels normalize to a 1-based UI regardless of the device base', () => {
+    const zeroBased = { fanLevels: [0, 1, 2, 3] };
+    const oneBased = { fanLevels: [1, 2, 3, 4] };
+
+    // A zero-based device is shifted up so the UI still starts at 1...
+    assert.deepEqual(fanLevelOptions(zeroBased).map((o) => o.id), ['1', '2', '3', '4']);
+    // ...and a one-based device is left as-is — it must NOT drift to [2,3,4,5].
+    assert.deepEqual(fanLevelOptions(oneBased).map((o) => o.id), ['1', '2', '3', '4']);
+
+    // Zero-based: UI 1 ↔ device 0.
+    assert.equal(fanlevelWriter.encode('1', zeroBased), 0);
+    assert.equal(fanlevelReader.decode(0, zeroBased), '1');
+    // One-based: UI 1 ↔ device 1 (no offset).
+    assert.equal(fanlevelWriter.encode('1', oneBased), 1);
+    assert.equal(fanlevelReader.decode(1, oneBased), '1');
+
+    // encode/decode round-trips for both conventions.
+    for (const desc of [zeroBased, oneBased]) {
+        for (const opt of fanLevelOptions(desc)) {
+            assert.equal(fanlevelReader.decode(fanlevelWriter.encode(opt.id, desc), desc), opt.id);
+        }
+    }
+});
+
+test('desiredCapabilities is derived from the declared props', () => {
+    // A prop switches its capability on; an absent prop leaves it off.
+    const withVertical = engine.desiredCapabilities({
+        props: { power: { siid: 2, piid: 1 }, swing_v: { siid: 2, piid: 8 }, swing_v_angle: { siid: 2, piid: 9 } }
+    });
+    assert.ok(withVertical.includes('onoff'));
+    assert.ok(withVertical.includes('fan_xiaomi_vertical_swing'));
+    assert.ok(withVertical.includes('fan_xiaomi_vertical_angle'));
+
+    const withoutVertical = engine.desiredCapabilities({ props: { power: { siid: 2, piid: 1 } } });
+    assert.ok(withoutVertical.includes('onoff'));
+    assert.ok(!withoutVertical.includes('fan_xiaomi_vertical_swing'));
+    assert.ok(!withoutVertical.includes('fan_xiaomi_vertical_angle'));
+});
+
+test('buildGetProperties only requests declared props', () => {
+    const desc = { props: { power: { siid: 2, piid: 1 }, mode: { siid: 2, piid: 3 } } };
+    const entries = engine.buildGetProperties(desc);
+    const dids = entries.map((e) => e.did).sort();
+
+    assert.deepEqual(dids, ['mode', 'power'], 'only declared props are requested');
+    for (const entry of entries) {
+        assert.equal(entry.siid, desc.props[entry.did].siid);
+        assert.equal(entry.piid, desc.props[entry.did].piid);
+    }
+});
+
+test('the first observation seeds the cache without firing a trigger', async () => {
+    const device = createMockDevice({ capabilities: ['fan_xiaomi_mode'] });
+    const desc = engine.resolve('xiaomi.fan.p70');
+
+    await engine.pollAndUpdate(device, desc, [{ did: 'mode', value: 0, code: 0 }]);
+    assert.equal(device._capabilityValues['fan_xiaomi_mode'], '0');
+    assert.equal(device._triggered.length, 0, 'no trigger on first observation');
+
+    // Same value again: still no trigger.
+    await engine.pollAndUpdate(device, desc, [{ did: 'mode', value: 0, code: 0 }]);
+    assert.equal(device._triggered.length, 0);
+});
+
+test('a physical change between polls fires exactly one trigger', async () => {
+    const device = createMockDevice({ capabilities: ['fan_xiaomi_horizontal_angle'] });
+    const desc = engine.resolve('xiaomi.fan.p70');
+
+    await engine.pollAndUpdate(device, desc, [{ did: 'swing_h_angle', value: 30, code: 0 }]); // seed
+    await engine.pollAndUpdate(device, desc, [{ did: 'swing_h_angle', value: 60, code: 0 }]); // change
+
+    assert.equal(device._triggered.length, 1);
+    const fired = device._triggered[0];
+    assert.equal(fired.card, 'xiaomiHorizontalAngleChanged');
+    // [5]: angle tokens are numeric, not "60°" strings.
+    assert.equal(typeof fired.tokens.new_angle, 'number');
+    assert.equal(fired.tokens.new_angle, 60);
+    assert.equal(fired.tokens.previous_angle, 30);
+});
+
+test('a Homey-initiated change is still detected (cache, not capability value)', async () => {
+    const device = createMockDevice({ capabilities: ['fan_xiaomi_mode'] });
+    const desc = engine.resolve('xiaomi.fan.p70');
+
+    await engine.pollAndUpdate(device, desc, [{ did: 'mode', value: 0, code: 0 }]); // seed at 0
+    assert.equal(device._triggered.length, 0);
+
+    // Homey optimistically set the capability when the user/Flow changed it.
+    device._capabilityValues['fan_xiaomi_mode'] = '1';
+
+    // The confirming poll must still fire, because the comparison is against the
+    // last observed device value (0), not the already-updated capability value.
+    await engine.pollAndUpdate(device, desc, [{ did: 'mode', value: 1, code: 0 }]);
+    assert.equal(device._triggered.length, 1);
+    assert.equal(device._triggered[0].card, 'xiaomiModeChanged');
+});
+
+test('invalid MIoT entries are skipped and never update state or fire', async () => {
+    const caps = ['fan_xiaomi_mode', 'fan_xiaomi_fanlevel', 'fan_xiaomi_horizontal_angle', 'fan_speed'];
+    const device = createMockDevice({ capabilities: caps });
+    const desc = engine.resolve('xiaomi.fan.p70');
+
+    // Seed with valid values.
+    await engine.pollAndUpdate(device, desc, [
+        { did: 'mode', value: 0, code: 0 },
+        { did: 'fan_level', value: 0, code: 0 },
+        { did: 'swing_h_angle', value: 30, code: 0 },
+        { did: 'fan_speed', value: 50, code: 0 }
+    ]);
+    const seeded = { ...device._capabilityValues };
+    assert.equal(device._triggered.length, 0);
+
+    // A batch of invalid observations: out-of-descriptor, null, error code, non-finite.
+    await engine.pollAndUpdate(device, desc, [
+        { did: 'mode', value: 99, code: 0 },            // 99 ∉ modes
+        { did: 'fan_level', value: null, code: 0 },     // null value
+        { did: 'swing_h_angle', value: 60, code: -4004 }, // device error code
+        { did: 'fan_speed', value: 'nope', code: 0 }    // non-finite
+    ]);
+
+    assert.deepEqual(device._capabilityValues, seeded, 'no capability changed by invalid reads');
+    assert.equal(device._triggered.length, 0, 'no trigger from invalid reads');
+});
+
+test('applyCapabilityOptions does not re-set unchanged options', async () => {
+    const caps = ['fan_xiaomi_mode', 'fan_xiaomi_fanlevel', 'fan_xiaomi_horizontal_angle', 'fan_xiaomi_vertical_angle'];
+    const device = createMockDevice({ capabilities: caps });
+    const desc = engine.resolve('xiaomi.fan.p70');
+
+    let setCount = 0;
+    const realSet = device.setCapabilityOptions;
+    device.setCapabilityOptions = async (cap, options) => { setCount += 1; return realSet(cap, options); };
+
+    await engine.applyCapabilityOptions(device, desc);
+    const firstPass = setCount;
+    assert.ok(firstPass > 0, 'options written on first apply');
+
+    await engine.applyCapabilityOptions(device, desc);
+    assert.equal(setCount, firstPass, 'second apply is a no-op (options unchanged)');
+});
+
+test('regular and immediate polls run serialized on one queue', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const order = [];
+    let calls = 0;
+
+    const miioCall = async () => {
+        const id = ++calls;
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        order.push(`start${id}`);
+        await new Promise((resolve) => setImmediate(resolve));
+        await new Promise((resolve) => setImmediate(resolve));
+        order.push(`end${id}`);
+        inFlight -= 1;
+        return [{ did: 'power', value: true, code: 0 }];
+    };
+
+    const device = createMockDevice({ capabilities: ['onoff'], miioCall });
+    const desc = engine.resolve('xiaomi.fan.p70');
+
+    // Kick off a regular poll and an immediate poll "at the same time".
+    await Promise.all([engine.poll(device, desc), engine.immediatePollAndUpdate(device, desc)]);
+
+    assert.equal(maxInFlight, 1, 'polls must never overlap');
+    assert.deepEqual(order, ['start1', 'end1', 'start2', 'end2'], 'polls complete in order');
+});


### PR DESCRIPTION
## Summary
Improvements to the `fan_xiaomi_advanced` driver: more flow cards plus a few runtime refinements.

Still fully data-driven (now settings too) — each model stays a single declarative descriptor.

**No migration and no re-pair needed** — already-paired devices pick up the new capability, options and flow cards automatically on update (reconciled in `onInit`).

## New flow cards
- **Actions** — `Set mode`, `Set fan level`.
- **Conditions** — `Mode is`, `Fan level is`, `Horizontal angle is`, `Vertical angle is` (all invertible via Homey's Invert).
- **Triggers** — `Mode changed`, `Fan level changed`, `Horizontal swing angle changed`, `Vertical swing angle changed`.

Each card is offered only on models that expose the matching capability.

## Under the hood
- **Fan level is now data-driven** — models declare their raw `fanLevels` (Gear values); zero-indexed models (e.g. p70) are handled by a display offset, replacing the old `normalize` flag. Values are always shown 1-based to the user (triggers included).
- **Declarative settings** — led / buzzer / childLock are described once and polled only on models that support them.
- **Driver-scoped, filtered cards** — the mode-changed trigger moved to `xiaomiModeChanged` (capability-filtered),
 instead of the global unfiltered card.
- **Invertible conditions** — the "is" conditions use `!{{is|is not}}`, so a single card covers both directions.
- **Reliable change triggers** — trigger detection uses the last value observed from the device (a device-local cache),
so mode / level / angle triggers fire on every real change — whether it came from the app, a Flow, or the physical fan (on the next poll).
- **Instant feedback for app / Flow changes** — an app- or Flow-initiated write is followed by an on-demand poll, so the tile (and its change trigger) updates right away instead of waiting for the next cycle; physical changes are picked up by regular polling.
- **Consistent wording** — English flow-card titles follow Homey's sentence-case house style.

## Validation
- `homey app build` succeeds
- `homey app validate --level publish` passes
- Verified on real hardware: **p70** and **p76**.

## Test
Tested to create an Advanced Virtual Device, showing fan status triggered by the new triggers

<img width="400" height="1206" alt="AVD" src="https://github.com/user-attachments/assets/09127691-8014-442f-a816-29d7cb7446a8" />
