### PR TITLE
Add supported translations for new light drivers

### DIFF
--- a/.homeycompose/capabilities/yeelight_lamp22_mode.json
+++ b/.homeycompose/capabilities/yeelight_lamp22_mode.json
@@ -2,7 +2,18 @@
   "type": "enum",
   "title": {
     "en": "My modes / scenes",
-    "nl": "Mijn modi / scenes"
+    "nl": "Mijn modi / scenes",
+    "da": "Mine tilstande / scener",
+    "de": "Meine Modi / Szenen",
+    "es": "Mis modos / escenas",
+    "fr": "Mes modes / scènes",
+    "it": "Le mie modalità / scene",
+    "no": "Mine moduser / scener",
+    "sv": "Mina lägen / scener",
+    "pl": "Moje tryby / sceny",
+    "ru": "Мои режимы / сцены",
+    "ko": "내 모드 / 장면",
+    "ar": "أوضاعي / المشاهد"
   },
   "getable": true,
   "setable": true,
@@ -12,79 +23,199 @@
       "id": "0",
       "title": {
         "en": "No scene",
-        "nl": "Geen scene"
+        "nl": "Geen scene",
+        "da": "Ingen scene",
+        "de": "Keine Szene",
+        "es": "Sin escena",
+        "fr": "Aucune scène",
+        "it": "Nessuna scena",
+        "no": "Ingen scene",
+        "sv": "Ingen scen",
+        "pl": "Brak sceny",
+        "ru": "Нет сцены",
+        "ko": "장면 없음",
+        "ar": "بدون وضع"
       }
     },
     {
       "id": "1",
       "title": {
         "en": "My mode 1",
-        "nl": "Mijn modus 1"
+        "nl": "Mijn modus 1",
+        "da": "Min tilstand 1",
+        "de": "Mein Modus 1",
+        "es": "Mi modo 1",
+        "fr": "Mon mode 1",
+        "it": "La mia modalità 1",
+        "no": "Min modus 1",
+        "sv": "Mitt läge 1",
+        "pl": "Mój tryb 1",
+        "ru": "Мой режим 1",
+        "ko": "내 모드 1",
+        "ar": "وضعي 1"
       }
     },
     {
       "id": "2",
       "title": {
         "en": "My mode 2",
-        "nl": "Mijn modus 2"
+        "nl": "Mijn modus 2",
+        "da": "Min tilstand 2",
+        "de": "Mein Modus 2",
+        "es": "Mi modo 2",
+        "fr": "Mon mode 2",
+        "it": "La mia modalità 2",
+        "no": "Min modus 2",
+        "sv": "Mitt läge 2",
+        "pl": "Mój tryb 2",
+        "ru": "Мой режим 2",
+        "ko": "내 모드 2",
+        "ar": "وضعي 2"
       }
     },
     {
       "id": "3",
       "title": {
         "en": "My mode 3",
-        "nl": "Mijn modus 3"
+        "nl": "Mijn modus 3",
+        "da": "Min tilstand 3",
+        "de": "Mein Modus 3",
+        "es": "Mi modo 3",
+        "fr": "Mon mode 3",
+        "it": "La mia modalità 3",
+        "no": "Min modus 3",
+        "sv": "Mitt läge 3",
+        "pl": "Mój tryb 3",
+        "ru": "Мой режим 3",
+        "ko": "내 모드 3",
+        "ar": "وضعي 3"
       }
     },
     {
       "id": "4",
       "title": {
         "en": "My mode 4",
-        "nl": "Mijn modus 4"
+        "nl": "Mijn modus 4",
+        "da": "Min tilstand 4",
+        "de": "Mein Modus 4",
+        "es": "Mi modo 4",
+        "fr": "Mon mode 4",
+        "it": "La mia modalità 4",
+        "no": "Min modus 4",
+        "sv": "Mitt läge 4",
+        "pl": "Mój tryb 4",
+        "ru": "Мой режим 4",
+        "ko": "내 모드 4",
+        "ar": "وضعي 4"
       }
     },
     {
       "id": "6",
       "title": {
         "en": "Office",
-        "nl": "Kantoor"
+        "nl": "Kantoor",
+        "da": "Kontor",
+        "de": "Büro",
+        "es": "Oficina",
+        "fr": "Bureau",
+        "it": "Ufficio",
+        "no": "Kontor",
+        "sv": "Kontor",
+        "pl": "Biuro",
+        "ru": "Офис",
+        "ko": "사무실",
+        "ar": "المكتب"
       }
     },
     {
       "id": "5",
       "title": {
         "en": "Reading",
-        "nl": "Lezen"
+        "nl": "Lezen",
+        "da": "Læsning",
+        "de": "Lesen",
+        "es": "Lectura",
+        "fr": "Lecture",
+        "it": "Lettura",
+        "no": "Lesing",
+        "sv": "Läsning",
+        "pl": "Czytanie",
+        "ru": "Чтение",
+        "ko": "독서",
+        "ar": "القراءة"
       }
     },
     {
       "id": "7",
       "title": {
         "en": "Leisure",
-        "nl": "Ontspanning"
+        "nl": "Ontspanning",
+        "da": "Fritid",
+        "de": "Freizeit",
+        "es": "Ocio",
+        "fr": "Loisir",
+        "it": "Tempo libero",
+        "no": "Fritid",
+        "sv": "Fritid",
+        "pl": "Wypoczynek",
+        "ru": "Отдых",
+        "ko": "여가",
+        "ar": "الاسترخاء"
       }
     },
     {
       "id": "9",
       "title": {
         "en": "Computer",
-        "nl": "Computer"
+        "nl": "Computer",
+        "da": "Computer",
+        "de": "Computer",
+        "es": "Ordenador",
+        "fr": "Ordinateur",
+        "it": "Computer",
+        "no": "Datamaskin",
+        "sv": "Dator",
+        "pl": "Komputer",
+        "ru": "Компьютер",
+        "ko": "컴퓨터",
+        "ar": "الكمبيوتر"
       }
     },
     {
       "id": "8",
       "title": {
         "en": "Warm",
-        "nl": "Warm"
+        "nl": "Warm",
+        "da": "Varm",
+        "de": "Warm",
+        "es": "Cálido",
+        "fr": "Chaud",
+        "it": "Calda",
+        "no": "Varm",
+        "sv": "Varm",
+        "pl": "Ciepły",
+        "ru": "Тёплый",
+        "ko": "따뜻함",
+        "ar": "دافئ"
       }
     },
     {
       "id": "10",
       "title": {
         "en": "Blinking",
-        "nl": "Knipperen"
+        "nl": "Knipperen",
+        "da": "Blinkende",
+        "de": "Blinken",
+        "es": "Parpadeo",
+        "fr": "Clignotement",
+        "it": "Lampeggiante",
+        "no": "Blinkende",
+        "sv": "Blinkande",
+        "pl": "Miganie",
+        "ru": "Мигание",
+        "ko": "깜박임",
+        "ar": "وميض"
       }
     }
-  ],
-  "icon": "/assets/icons/airpurifier-mode.svg"
+  ]
 }

--- a/.homeycompose/flow/actions/yeelightLamp22Mode.json
+++ b/.homeycompose/flow/actions/yeelightLamp22Mode.json
@@ -1,18 +1,51 @@
 {
   "title": {
     "en": "Set my mode / scene",
-    "nl": "Stel mijn modus / scene in"
+    "nl": "Stel mijn modus / scene in",
+    "da": "Indstil min tilstand / scene",
+    "de": "Meinen Modus / meine Szene einstellen",
+    "es": "Establecer mi modo / escena",
+    "fr": "Définir mon mode / ma scène",
+    "it": "Imposta la mia modalità / scena",
+    "no": "Sett min modus / scene",
+    "sv": "Ställ in mitt läge / min scen",
+    "pl": "Ustaw mój tryb / scenę",
+    "ru": "Установить мой режим / сцену",
+    "ko": "내 모드 / 장면 설정",
+    "ar": "تعيين وضعي / المشهد"
   },
   "titleFormatted": {
     "en": "Set my mode / scene to [[mode]]",
-    "nl": "Stel mijn modus / scene in op [[mode]]"
+    "nl": "Stel mijn modus / scene in op [[mode]]",
+    "da": "Indstil min tilstand / scene til [[mode]]",
+    "de": "Meinen Modus / meine Szene auf [[mode]] einstellen",
+    "es": "Establecer mi modo / escena en [[mode]]",
+    "fr": "Définir mon mode / ma scène sur [[mode]]",
+    "it": "Imposta la mia modalità / scena su [[mode]]",
+    "no": "Sett min modus / scene til [[mode]]",
+    "sv": "Ställ in mitt läge / min scen till [[mode]]",
+    "pl": "Ustaw mój tryb / scenę na [[mode]]",
+    "ru": "Установить мой режим / сцену: [[mode]]",
+    "ko": "내 모드 / 장면을 [[mode]](으)로 설정",
+    "ar": "تعيين وضعي / المشهد إلى [[mode]]"
   },
   "args": [
     {
       "name": "mode",
       "title": {
         "en": "My mode / scene",
-        "nl": "Mijn modus / scene"
+        "nl": "Mijn modus / scene",
+        "da": "Min tilstand / scene",
+        "de": "Mein Modus / meine Szene",
+        "es": "Mi modo / escena",
+        "fr": "Mon mode / ma scène",
+        "it": "La mia modalità / scena",
+        "no": "Min modus / scene",
+        "sv": "Mitt läge / min scen",
+        "pl": "Mój tryb / scena",
+        "ru": "Мой режим / сцена",
+        "ko": "내 모드 / 장면",
+        "ar": "وضعي / المشهد"
       },
       "type": "dropdown",
       "values": [
@@ -20,77 +53,198 @@
           "id": "0",
           "title": {
             "en": "No scene",
-            "nl": "Geen scene"
+            "nl": "Geen scene",
+            "da": "Ingen scene",
+            "de": "Keine Szene",
+            "es": "Sin escena",
+            "fr": "Aucune scène",
+            "it": "Nessuna scena",
+            "no": "Ingen scene",
+            "sv": "Ingen scen",
+            "pl": "Brak sceny",
+            "ru": "Нет сцены",
+            "ko": "장면 없음",
+            "ar": "بدون وضع"
           }
         },
         {
           "id": "1",
           "title": {
             "en": "My mode 1",
-            "nl": "Mijn modus 1"
+            "nl": "Mijn modus 1",
+            "da": "Min tilstand 1",
+            "de": "Mein Modus 1",
+            "es": "Mi modo 1",
+            "fr": "Mon mode 1",
+            "it": "La mia modalità 1",
+            "no": "Min modus 1",
+            "sv": "Mitt läge 1",
+            "pl": "Mój tryb 1",
+            "ru": "Мой режим 1",
+            "ko": "내 모드 1",
+            "ar": "وضعي 1"
           }
         },
         {
           "id": "2",
           "title": {
             "en": "My mode 2",
-            "nl": "Mijn modus 2"
+            "nl": "Mijn modus 2",
+            "da": "Min tilstand 2",
+            "de": "Mein Modus 2",
+            "es": "Mi modo 2",
+            "fr": "Mon mode 2",
+            "it": "La mia modalità 2",
+            "no": "Min modus 2",
+            "sv": "Mitt läge 2",
+            "pl": "Mój tryb 2",
+            "ru": "Мой режим 2",
+            "ko": "내 모드 2",
+            "ar": "وضعي 2"
           }
         },
         {
           "id": "3",
           "title": {
             "en": "My mode 3",
-            "nl": "Mijn modus 3"
+            "nl": "Mijn modus 3",
+            "da": "Min tilstand 3",
+            "de": "Mein Modus 3",
+            "es": "Mi modo 3",
+            "fr": "Mon mode 3",
+            "it": "La mia modalità 3",
+            "no": "Min modus 3",
+            "sv": "Mitt läge 3",
+            "pl": "Mój tryb 3",
+            "ru": "Мой режим 3",
+            "ko": "내 모드 3",
+            "ar": "وضعي 3"
           }
         },
         {
           "id": "4",
           "title": {
             "en": "My mode 4",
-            "nl": "Mijn modus 4"
+            "nl": "Mijn modus 4",
+            "da": "Min tilstand 4",
+            "de": "Mein Modus 4",
+            "es": "Mi modo 4",
+            "fr": "Mon mode 4",
+            "it": "La mia modalità 4",
+            "no": "Min modus 4",
+            "sv": "Mitt läge 4",
+            "pl": "Mój tryb 4",
+            "ru": "Мой режим 4",
+            "ko": "내 모드 4",
+            "ar": "وضعي 4"
           }
         },
         {
           "id": "6",
           "title": {
             "en": "Office",
-            "nl": "Kantoor"
+            "nl": "Kantoor",
+            "da": "Kontor",
+            "de": "Büro",
+            "es": "Oficina",
+            "fr": "Bureau",
+            "it": "Ufficio",
+            "no": "Kontor",
+            "sv": "Kontor",
+            "pl": "Biuro",
+            "ru": "Офис",
+            "ko": "사무실",
+            "ar": "المكتب"
           }
         },
         {
           "id": "5",
           "title": {
             "en": "Reading",
-            "nl": "Lezen"
+            "nl": "Lezen",
+            "da": "Læsning",
+            "de": "Lesen",
+            "es": "Lectura",
+            "fr": "Lecture",
+            "it": "Lettura",
+            "no": "Lesing",
+            "sv": "Läsning",
+            "pl": "Czytanie",
+            "ru": "Чтение",
+            "ko": "독서",
+            "ar": "القراءة"
           }
         },
         {
           "id": "7",
           "title": {
             "en": "Leisure",
-            "nl": "Ontspanning"
+            "nl": "Ontspanning",
+            "da": "Fritid",
+            "de": "Freizeit",
+            "es": "Ocio",
+            "fr": "Loisir",
+            "it": "Tempo libero",
+            "no": "Fritid",
+            "sv": "Fritid",
+            "pl": "Wypoczynek",
+            "ru": "Отдых",
+            "ko": "여가",
+            "ar": "الاسترخاء"
           }
         },
         {
           "id": "9",
           "title": {
             "en": "Computer",
-            "nl": "Computer"
+            "nl": "Computer",
+            "da": "Computer",
+            "de": "Computer",
+            "es": "Ordenador",
+            "fr": "Ordinateur",
+            "it": "Computer",
+            "no": "Datamaskin",
+            "sv": "Dator",
+            "pl": "Komputer",
+            "ru": "Компьютер",
+            "ko": "컴퓨터",
+            "ar": "الكمبيوتر"
           }
         },
         {
           "id": "8",
           "title": {
             "en": "Warm",
-            "nl": "Warm"
+            "nl": "Warm",
+            "da": "Varm",
+            "de": "Warm",
+            "es": "Cálido",
+            "fr": "Chaud",
+            "it": "Calda",
+            "no": "Varm",
+            "sv": "Varm",
+            "pl": "Ciepły",
+            "ru": "Тёплый",
+            "ko": "따뜻함",
+            "ar": "دافئ"
           }
         },
         {
           "id": "10",
           "title": {
             "en": "Blinking",
-            "nl": "Knipperen"
+            "nl": "Knipperen",
+            "da": "Blinkende",
+            "de": "Blinken",
+            "es": "Parpadeo",
+            "fr": "Clignotement",
+            "it": "Lampeggiante",
+            "no": "Blinkende",
+            "sv": "Blinkande",
+            "pl": "Miganie",
+            "ru": "Мигание",
+            "ko": "깜박임",
+            "ar": "وميض"
           }
         }
       ]
@@ -100,7 +254,18 @@
       "type": "device",
       "placeholder": {
         "en": "Select Xiaomi Monitor Light Bar S1",
-        "nl": "Selecteer Xiaomi Monitor Light Bar S1"
+        "nl": "Selecteer Xiaomi Monitor Light Bar S1",
+        "da": "Vælg Xiaomi Monitor Light Bar S1",
+        "de": "Xiaomi Monitor Light Bar S1 auswählen",
+        "es": "Selecciona Xiaomi Monitor Light Bar S1",
+        "fr": "Sélectionnez Xiaomi Monitor Light Bar S1",
+        "it": "Seleziona Xiaomi Monitor Light Bar S1",
+        "no": "Velg Xiaomi Monitor Light Bar S1",
+        "sv": "Välj Xiaomi Monitor Light Bar S1",
+        "pl": "Wybierz Xiaomi Monitor Light Bar S1",
+        "ru": "Выберите Xiaomi Monitor Light Bar S1",
+        "ko": "Xiaomi Monitor Light Bar S1 선택",
+        "ar": "اختر Xiaomi Monitor Light Bar S1"
       },
       "filter": "driver_id=yeelink_light_lamp22_miot"
     }

--- a/.homeycompose/flow/conditions/yeelightLamp22ModeIs.json
+++ b/.homeycompose/flow/conditions/yeelightLamp22ModeIs.json
@@ -1,18 +1,51 @@
 {
   "title": {
     "en": "My mode / scene is",
-    "nl": "Mijn modus / scene is"
+    "nl": "Mijn modus / scene is",
+    "da": "Min tilstand / scene er",
+    "de": "Mein Modus / meine Szene ist",
+    "es": "Mi modo / escena es",
+    "fr": "Mon mode / ma scène est",
+    "it": "La mia modalità / scena è",
+    "no": "Min modus / scene er",
+    "sv": "Mitt läge / min scen är",
+    "pl": "Mój tryb / scena to",
+    "ru": "Мой режим / сцена",
+    "ko": "내 모드 / 장면 상태",
+    "ar": "وضعي / المشهد هو"
   },
   "titleFormatted": {
     "en": "My mode / scene is [[mode]]",
-    "nl": "Mijn modus / scene is [[mode]]"
+    "nl": "Mijn modus / scene is [[mode]]",
+    "da": "Min tilstand / scene er [[mode]]",
+    "de": "Mein Modus / meine Szene ist [[mode]]",
+    "es": "Mi modo / escena es [[mode]]",
+    "fr": "Mon mode / ma scène est [[mode]]",
+    "it": "La mia modalità / scena è [[mode]]",
+    "no": "Min modus / scene er [[mode]]",
+    "sv": "Mitt läge / min scen är [[mode]]",
+    "pl": "Mój tryb / scena to [[mode]]",
+    "ru": "Мой режим / сцена: [[mode]]",
+    "ko": "내 모드 / 장면이 [[mode]]임",
+    "ar": "وضعي / المشهد هو [[mode]]"
   },
   "args": [
     {
       "name": "mode",
       "title": {
         "en": "My mode / scene",
-        "nl": "Mijn modus / scene"
+        "nl": "Mijn modus / scene",
+        "da": "Min tilstand / scene",
+        "de": "Mein Modus / meine Szene",
+        "es": "Mi modo / escena",
+        "fr": "Mon mode / ma scène",
+        "it": "La mia modalità / scena",
+        "no": "Min modus / scene",
+        "sv": "Mitt läge / min scen",
+        "pl": "Mój tryb / scena",
+        "ru": "Мой режим / сцена",
+        "ko": "내 모드 / 장면",
+        "ar": "وضعي / المشهد"
       },
       "type": "dropdown",
       "values": [
@@ -20,77 +53,198 @@
           "id": "0",
           "title": {
             "en": "No scene",
-            "nl": "Geen scene"
+            "nl": "Geen scene",
+            "da": "Ingen scene",
+            "de": "Keine Szene",
+            "es": "Sin escena",
+            "fr": "Aucune scène",
+            "it": "Nessuna scena",
+            "no": "Ingen scene",
+            "sv": "Ingen scen",
+            "pl": "Brak sceny",
+            "ru": "Нет сцены",
+            "ko": "장면 없음",
+            "ar": "بدون وضع"
           }
         },
         {
           "id": "1",
           "title": {
             "en": "My mode 1",
-            "nl": "Mijn modus 1"
+            "nl": "Mijn modus 1",
+            "da": "Min tilstand 1",
+            "de": "Mein Modus 1",
+            "es": "Mi modo 1",
+            "fr": "Mon mode 1",
+            "it": "La mia modalità 1",
+            "no": "Min modus 1",
+            "sv": "Mitt läge 1",
+            "pl": "Mój tryb 1",
+            "ru": "Мой режим 1",
+            "ko": "내 모드 1",
+            "ar": "وضعي 1"
           }
         },
         {
           "id": "2",
           "title": {
             "en": "My mode 2",
-            "nl": "Mijn modus 2"
+            "nl": "Mijn modus 2",
+            "da": "Min tilstand 2",
+            "de": "Mein Modus 2",
+            "es": "Mi modo 2",
+            "fr": "Mon mode 2",
+            "it": "La mia modalità 2",
+            "no": "Min modus 2",
+            "sv": "Mitt läge 2",
+            "pl": "Mój tryb 2",
+            "ru": "Мой режим 2",
+            "ko": "내 모드 2",
+            "ar": "وضعي 2"
           }
         },
         {
           "id": "3",
           "title": {
             "en": "My mode 3",
-            "nl": "Mijn modus 3"
+            "nl": "Mijn modus 3",
+            "da": "Min tilstand 3",
+            "de": "Mein Modus 3",
+            "es": "Mi modo 3",
+            "fr": "Mon mode 3",
+            "it": "La mia modalità 3",
+            "no": "Min modus 3",
+            "sv": "Mitt läge 3",
+            "pl": "Mój tryb 3",
+            "ru": "Мой режим 3",
+            "ko": "내 모드 3",
+            "ar": "وضعي 3"
           }
         },
         {
           "id": "4",
           "title": {
             "en": "My mode 4",
-            "nl": "Mijn modus 4"
+            "nl": "Mijn modus 4",
+            "da": "Min tilstand 4",
+            "de": "Mein Modus 4",
+            "es": "Mi modo 4",
+            "fr": "Mon mode 4",
+            "it": "La mia modalità 4",
+            "no": "Min modus 4",
+            "sv": "Mitt läge 4",
+            "pl": "Mój tryb 4",
+            "ru": "Мой режим 4",
+            "ko": "내 모드 4",
+            "ar": "وضعي 4"
           }
         },
         {
           "id": "6",
           "title": {
             "en": "Office",
-            "nl": "Kantoor"
+            "nl": "Kantoor",
+            "da": "Kontor",
+            "de": "Büro",
+            "es": "Oficina",
+            "fr": "Bureau",
+            "it": "Ufficio",
+            "no": "Kontor",
+            "sv": "Kontor",
+            "pl": "Biuro",
+            "ru": "Офис",
+            "ko": "사무실",
+            "ar": "المكتب"
           }
         },
         {
           "id": "5",
           "title": {
             "en": "Reading",
-            "nl": "Lezen"
+            "nl": "Lezen",
+            "da": "Læsning",
+            "de": "Lesen",
+            "es": "Lectura",
+            "fr": "Lecture",
+            "it": "Lettura",
+            "no": "Lesing",
+            "sv": "Läsning",
+            "pl": "Czytanie",
+            "ru": "Чтение",
+            "ko": "독서",
+            "ar": "القراءة"
           }
         },
         {
           "id": "7",
           "title": {
             "en": "Leisure",
-            "nl": "Ontspanning"
+            "nl": "Ontspanning",
+            "da": "Fritid",
+            "de": "Freizeit",
+            "es": "Ocio",
+            "fr": "Loisir",
+            "it": "Tempo libero",
+            "no": "Fritid",
+            "sv": "Fritid",
+            "pl": "Wypoczynek",
+            "ru": "Отдых",
+            "ko": "여가",
+            "ar": "الاسترخاء"
           }
         },
         {
           "id": "9",
           "title": {
             "en": "Computer",
-            "nl": "Computer"
+            "nl": "Computer",
+            "da": "Computer",
+            "de": "Computer",
+            "es": "Ordenador",
+            "fr": "Ordinateur",
+            "it": "Computer",
+            "no": "Datamaskin",
+            "sv": "Dator",
+            "pl": "Komputer",
+            "ru": "Компьютер",
+            "ko": "컴퓨터",
+            "ar": "الكمبيوتر"
           }
         },
         {
           "id": "8",
           "title": {
             "en": "Warm",
-            "nl": "Warm"
+            "nl": "Warm",
+            "da": "Varm",
+            "de": "Warm",
+            "es": "Cálido",
+            "fr": "Chaud",
+            "it": "Calda",
+            "no": "Varm",
+            "sv": "Varm",
+            "pl": "Ciepły",
+            "ru": "Тёплый",
+            "ko": "따뜻함",
+            "ar": "دافئ"
           }
         },
         {
           "id": "10",
           "title": {
             "en": "Blinking",
-            "nl": "Knipperen"
+            "nl": "Knipperen",
+            "da": "Blinkende",
+            "de": "Blinken",
+            "es": "Parpadeo",
+            "fr": "Clignotement",
+            "it": "Lampeggiante",
+            "no": "Blinkende",
+            "sv": "Blinkande",
+            "pl": "Miganie",
+            "ru": "Мигание",
+            "ko": "깜박임",
+            "ar": "وميض"
           }
         }
       ]
@@ -100,7 +254,18 @@
       "type": "device",
       "placeholder": {
         "en": "Select Xiaomi Monitor Light Bar S1",
-        "nl": "Selecteer Xiaomi Monitor Light Bar S1"
+        "nl": "Selecteer Xiaomi Monitor Light Bar S1",
+        "da": "Vælg Xiaomi Monitor Light Bar S1",
+        "de": "Xiaomi Monitor Light Bar S1 auswählen",
+        "es": "Selecciona Xiaomi Monitor Light Bar S1",
+        "fr": "Sélectionnez Xiaomi Monitor Light Bar S1",
+        "it": "Seleziona Xiaomi Monitor Light Bar S1",
+        "no": "Velg Xiaomi Monitor Light Bar S1",
+        "sv": "Välj Xiaomi Monitor Light Bar S1",
+        "pl": "Wybierz Xiaomi Monitor Light Bar S1",
+        "ru": "Выберите Xiaomi Monitor Light Bar S1",
+        "ko": "Xiaomi Monitor Light Bar S1 선택",
+        "ar": "اختر Xiaomi Monitor Light Bar S1"
       },
       "filter": "driver_id=yeelink_light_lamp22_miot"
     }

--- a/.homeycompose/flow/triggers/yeelightLamp22ModeChanged.json
+++ b/.homeycompose/flow/triggers/yeelightLamp22ModeChanged.json
@@ -1,11 +1,33 @@
 {
   "title": {
     "en": "My mode / scene changed to",
-    "nl": "Mijn modus / scene gewijzigd naar"
+    "nl": "Mijn modus / scene gewijzigd naar",
+    "da": "Min tilstand / scene ændret til",
+    "de": "Mein Modus / meine Szene geändert zu",
+    "es": "Mi modo / escena cambió a",
+    "fr": "Mon mode / ma scène a changé en",
+    "it": "La mia modalità / scena è cambiata in",
+    "no": "Min modus / scene endret til",
+    "sv": "Mitt läge / min scen ändrades till",
+    "pl": "Mój tryb / scena zmienił(a) się na",
+    "ru": "Мой режим / сцена изменился на",
+    "ko": "내 모드 / 장면 변경됨",
+    "ar": "تغير وضعي / المشهد إلى"
   },
   "titleFormatted": {
     "en": "My mode / scene changed to [[mode]]",
-    "nl": "Mijn modus / scene gewijzigd naar [[mode]]"
+    "nl": "Mijn modus / scene gewijzigd naar [[mode]]",
+    "da": "Min tilstand / scene ændret til [[mode]]",
+    "de": "Mein Modus / meine Szene geändert zu [[mode]]",
+    "es": "Mi modo / escena cambió a [[mode]]",
+    "fr": "Mon mode / ma scène a changé en [[mode]]",
+    "it": "La mia modalità / scena è cambiata in [[mode]]",
+    "no": "Min modus / scene endret til [[mode]]",
+    "sv": "Mitt läge / min scen ändrades till [[mode]]",
+    "pl": "Mój tryb / scena zmienił(a) się na [[mode]]",
+    "ru": "Мой режим / сцена изменился на [[mode]]",
+    "ko": "내 모드 / 장면이 [[mode]](으)로 변경됨",
+    "ar": "تغير وضعي / المشهد إلى [[mode]]"
   },
   "tokens": [
     {
@@ -13,7 +35,18 @@
       "type": "string",
       "title": {
         "en": "my mode / scene",
-        "nl": "mijn modus / scene"
+        "nl": "mijn modus / scene",
+        "da": "min tilstand / scene",
+        "de": "mein Modus / meine Szene",
+        "es": "mi modo / escena",
+        "fr": "mon mode / ma scène",
+        "it": "la mia modalità / scena",
+        "no": "min modus / scene",
+        "sv": "mitt läge / min scen",
+        "pl": "mój tryb / scena",
+        "ru": "мой режим / сцена",
+        "ko": "내 모드 / 장면",
+        "ar": "وضعي / المشهد"
       },
       "example": "Reading"
     },
@@ -22,7 +55,18 @@
       "type": "string",
       "title": {
         "en": "previous my mode / scene",
-        "nl": "vorige mijn modus / scene"
+        "nl": "vorige mijn modus / scene",
+        "da": "forrige min tilstand / scene",
+        "de": "vorheriger Modus / vorherige Szene",
+        "es": "mi modo / escena anterior",
+        "fr": "mode / scène précédent",
+        "it": "modalità / scena precedente",
+        "no": "forrige min modus / scene",
+        "sv": "föregående läge / scen",
+        "pl": "poprzedni mój tryb / scena",
+        "ru": "предыдущий режим / сцена",
+        "ko": "이전 내 모드 / 장면",
+        "ar": "وضعي / المشهد السابق"
       },
       "example": "My mode 1"
     }
@@ -32,7 +76,18 @@
       "name": "mode",
       "title": {
         "en": "My mode / scene",
-        "nl": "Mijn modus / scene"
+        "nl": "Mijn modus / scene",
+        "da": "Min tilstand / scene",
+        "de": "Mein Modus / meine Szene",
+        "es": "Mi modo / escena",
+        "fr": "Mon mode / ma scène",
+        "it": "La mia modalità / scena",
+        "no": "Min modus / scene",
+        "sv": "Mitt läge / min scen",
+        "pl": "Mój tryb / scena",
+        "ru": "Мой режим / сцена",
+        "ko": "내 모드 / 장면",
+        "ar": "وضعي / المشهد"
       },
       "type": "dropdown",
       "values": [
@@ -40,77 +95,198 @@
           "id": "0",
           "title": {
             "en": "No scene",
-            "nl": "Geen scene"
+            "nl": "Geen scene",
+            "da": "Ingen scene",
+            "de": "Keine Szene",
+            "es": "Sin escena",
+            "fr": "Aucune scène",
+            "it": "Nessuna scena",
+            "no": "Ingen scene",
+            "sv": "Ingen scen",
+            "pl": "Brak sceny",
+            "ru": "Нет сцены",
+            "ko": "장면 없음",
+            "ar": "بدون وضع"
           }
         },
         {
           "id": "1",
           "title": {
             "en": "My mode 1",
-            "nl": "Mijn modus 1"
+            "nl": "Mijn modus 1",
+            "da": "Min tilstand 1",
+            "de": "Mein Modus 1",
+            "es": "Mi modo 1",
+            "fr": "Mon mode 1",
+            "it": "La mia modalità 1",
+            "no": "Min modus 1",
+            "sv": "Mitt läge 1",
+            "pl": "Mój tryb 1",
+            "ru": "Мой режим 1",
+            "ko": "내 모드 1",
+            "ar": "وضعي 1"
           }
         },
         {
           "id": "2",
           "title": {
             "en": "My mode 2",
-            "nl": "Mijn modus 2"
+            "nl": "Mijn modus 2",
+            "da": "Min tilstand 2",
+            "de": "Mein Modus 2",
+            "es": "Mi modo 2",
+            "fr": "Mon mode 2",
+            "it": "La mia modalità 2",
+            "no": "Min modus 2",
+            "sv": "Mitt läge 2",
+            "pl": "Mój tryb 2",
+            "ru": "Мой режим 2",
+            "ko": "내 모드 2",
+            "ar": "وضعي 2"
           }
         },
         {
           "id": "3",
           "title": {
             "en": "My mode 3",
-            "nl": "Mijn modus 3"
+            "nl": "Mijn modus 3",
+            "da": "Min tilstand 3",
+            "de": "Mein Modus 3",
+            "es": "Mi modo 3",
+            "fr": "Mon mode 3",
+            "it": "La mia modalità 3",
+            "no": "Min modus 3",
+            "sv": "Mitt läge 3",
+            "pl": "Mój tryb 3",
+            "ru": "Мой режим 3",
+            "ko": "내 모드 3",
+            "ar": "وضعي 3"
           }
         },
         {
           "id": "4",
           "title": {
             "en": "My mode 4",
-            "nl": "Mijn modus 4"
+            "nl": "Mijn modus 4",
+            "da": "Min tilstand 4",
+            "de": "Mein Modus 4",
+            "es": "Mi modo 4",
+            "fr": "Mon mode 4",
+            "it": "La mia modalità 4",
+            "no": "Min modus 4",
+            "sv": "Mitt läge 4",
+            "pl": "Mój tryb 4",
+            "ru": "Мой режим 4",
+            "ko": "내 모드 4",
+            "ar": "وضعي 4"
           }
         },
         {
           "id": "6",
           "title": {
             "en": "Office",
-            "nl": "Kantoor"
+            "nl": "Kantoor",
+            "da": "Kontor",
+            "de": "Büro",
+            "es": "Oficina",
+            "fr": "Bureau",
+            "it": "Ufficio",
+            "no": "Kontor",
+            "sv": "Kontor",
+            "pl": "Biuro",
+            "ru": "Офис",
+            "ko": "사무실",
+            "ar": "المكتب"
           }
         },
         {
           "id": "5",
           "title": {
             "en": "Reading",
-            "nl": "Lezen"
+            "nl": "Lezen",
+            "da": "Læsning",
+            "de": "Lesen",
+            "es": "Lectura",
+            "fr": "Lecture",
+            "it": "Lettura",
+            "no": "Lesing",
+            "sv": "Läsning",
+            "pl": "Czytanie",
+            "ru": "Чтение",
+            "ko": "독서",
+            "ar": "القراءة"
           }
         },
         {
           "id": "7",
           "title": {
             "en": "Leisure",
-            "nl": "Ontspanning"
+            "nl": "Ontspanning",
+            "da": "Fritid",
+            "de": "Freizeit",
+            "es": "Ocio",
+            "fr": "Loisir",
+            "it": "Tempo libero",
+            "no": "Fritid",
+            "sv": "Fritid",
+            "pl": "Wypoczynek",
+            "ru": "Отдых",
+            "ko": "여가",
+            "ar": "الاسترخاء"
           }
         },
         {
           "id": "9",
           "title": {
             "en": "Computer",
-            "nl": "Computer"
+            "nl": "Computer",
+            "da": "Computer",
+            "de": "Computer",
+            "es": "Ordenador",
+            "fr": "Ordinateur",
+            "it": "Computer",
+            "no": "Datamaskin",
+            "sv": "Dator",
+            "pl": "Komputer",
+            "ru": "Компьютер",
+            "ko": "컴퓨터",
+            "ar": "الكمبيوتر"
           }
         },
         {
           "id": "8",
           "title": {
             "en": "Warm",
-            "nl": "Warm"
+            "nl": "Warm",
+            "da": "Varm",
+            "de": "Warm",
+            "es": "Cálido",
+            "fr": "Chaud",
+            "it": "Calda",
+            "no": "Varm",
+            "sv": "Varm",
+            "pl": "Ciepły",
+            "ru": "Тёплый",
+            "ko": "따뜻함",
+            "ar": "دافئ"
           }
         },
         {
           "id": "10",
           "title": {
             "en": "Blinking",
-            "nl": "Knipperen"
+            "nl": "Knipperen",
+            "da": "Blinkende",
+            "de": "Blinken",
+            "es": "Parpadeo",
+            "fr": "Clignotement",
+            "it": "Lampeggiante",
+            "no": "Blinkende",
+            "sv": "Blinkande",
+            "pl": "Miganie",
+            "ru": "Мигание",
+            "ko": "깜박임",
+            "ar": "وميض"
           }
         }
       ]
@@ -120,7 +296,18 @@
       "type": "device",
       "placeholder": {
         "en": "Select Xiaomi Monitor Light Bar S1",
-        "nl": "Selecteer Xiaomi Monitor Light Bar S1"
+        "nl": "Selecteer Xiaomi Monitor Light Bar S1",
+        "da": "Vælg Xiaomi Monitor Light Bar S1",
+        "de": "Xiaomi Monitor Light Bar S1 auswählen",
+        "es": "Selecciona Xiaomi Monitor Light Bar S1",
+        "fr": "Sélectionnez Xiaomi Monitor Light Bar S1",
+        "it": "Seleziona Xiaomi Monitor Light Bar S1",
+        "no": "Velg Xiaomi Monitor Light Bar S1",
+        "sv": "Välj Xiaomi Monitor Light Bar S1",
+        "pl": "Wybierz Xiaomi Monitor Light Bar S1",
+        "ru": "Выберите Xiaomi Monitor Light Bar S1",
+        "ko": "Xiaomi Monitor Light Bar S1 선택",
+        "ar": "اختر Xiaomi Monitor Light Bar S1"
       },
       "filter": "driver_id=yeelink_light_lamp22_miot"
     }

--- a/drivers/yeelink_light_color1_lan/driver.compose.json
+++ b/drivers/yeelink_light_color1_lan/driver.compose.json
@@ -11,11 +11,23 @@
     "sv": "Yeelight Color Bulb (legacy LAN) (WiFi)",
     "pl": "Yeelight Color Bulb (legacy LAN) (WiFi)",
     "ru": "Yeelight Color Bulb (legacy LAN) (WiFi)",
-    "ko": "Yeelight Color Bulb (legacy LAN) (WiFi)"
+    "ko": "Yeelight Color Bulb (legacy LAN) (WiFi)",
+    "ar": "Yeelight Color Bulb (legacy LAN) (WiFi)"
   },
   "description": {
     "en": "Product model: YLDP02YL. Uses the legacy Yeelight LAN API.",
-    "nl": "Productmodel: YLDP02YL. Gebruikt de legacy Yeelight LAN API."
+    "nl": "Productmodel: YLDP02YL. Gebruikt de legacy Yeelight LAN API.",
+    "da": "Produktmodel: YLDP02YL. Bruger den ældre Yeelight LAN API.",
+    "de": "Produktmodell: YLDP02YL. Verwendet die ältere Yeelight LAN-API.",
+    "es": "Modelo del producto: YLDP02YL. Usa la API LAN heredada de Yeelight.",
+    "fr": "Modèle du produit : YLDP02YL. Utilise l’ancienne API LAN Yeelight.",
+    "it": "Modello prodotto: YLDP02YL. Usa l’API LAN legacy di Yeelight.",
+    "no": "Produktmodell: YLDP02YL. Bruker den eldre Yeelight LAN-API-en.",
+    "sv": "Produktmodell: YLDP02YL. Använder det äldre Yeelight LAN-API:t.",
+    "pl": "Model produktu: YLDP02YL. Używa starszego API LAN Yeelight.",
+    "ru": "Модель продукта: YLDP02YL. Использует устаревший LAN API Yeelight.",
+    "ko": "제품 모델: YLDP02YL. 레거시 Yeelight LAN API를 사용합니다.",
+    "ar": "طراز المنتج: YLDP02YL. يستخدم واجهة Yeelight LAN API القديمة."
   },
   "images": {
     "large": "drivers/yeelink_light_color1_lan/assets/images/large.jpg",

--- a/drivers/yeelink_light_lamp22_miot/driver.compose.json
+++ b/drivers/yeelink_light_lamp22_miot/driver.compose.json
@@ -11,11 +11,23 @@
     "sv": "Xiaomi Monitor Light Bar S1 (WiFi)",
     "pl": "Xiaomi Monitor Light Bar S1 (WiFi)",
     "ru": "Xiaomi Monitor Light Bar S1 (WiFi)",
-    "ko": "Xiaomi Monitor Light Bar S1 (WiFi)"
+    "ko": "Xiaomi Monitor Light Bar S1 (WiFi)",
+    "ar": "Xiaomi Monitor Light Bar S1 (WiFi)"
   },
   "description": {
     "en": "Product model: MJGJD02YL",
-    "nl": "Productmodel: MJGJD02YL"
+    "nl": "Productmodel: MJGJD02YL",
+    "da": "Produktmodel: MJGJD02YL",
+    "de": "Produktmodell: MJGJD02YL",
+    "es": "Modelo del producto: MJGJD02YL",
+    "fr": "Modèle du produit : MJGJD02YL",
+    "it": "Modello prodotto: MJGJD02YL",
+    "no": "Produktmodell: MJGJD02YL",
+    "sv": "Produktmodell: MJGJD02YL",
+    "pl": "Model produktu: MJGJD02YL",
+    "ru": "Модель продукта: MJGJD02YL",
+    "ko": "제품 모델: MJGJD02YL",
+    "ar": "طراز المنتج: MJGJD02YL"
   },
   "images": {
     "large": "drivers/yeelink_light_lamp22_miot/assets/images/large.jpg",

--- a/drivers/yeelink_light_lamp22_miot/driver.settings.compose.json
+++ b/drivers/yeelink_light_lamp22_miot/driver.settings.compose.json
@@ -14,8 +14,7 @@
       "pl": "Ustawienia urządzenia",
       "ru": "Настройки устройства",
       "ko": "장치 설정",
-      "ja": "デバイス設定",
-      "zh": "设备设置"
+      "ar": "إعدادات الجهاز"
     },
     "children": [
       {
@@ -36,7 +35,18 @@
         },
         "label": {
           "en": "Polling rate (seconds)",
-          "nl": "Pollingfrequentie (seconden)"
+          "nl": "Pollingfrequentie (seconden)",
+          "da": "Pollinginterval (sekunder)",
+          "de": "Abfrageintervall (Sekunden)",
+          "es": "Frecuencia de sondeo (segundos)",
+          "fr": "Intervalle d’interrogation (secondes)",
+          "it": "Intervallo di polling (secondi)",
+          "no": "Pollingintervall (sekunder)",
+          "sv": "Pollningsintervall (sekunder)",
+          "pl": "Interwał odpytywania (sekundy)",
+          "ru": "Интервал опроса (секунды)",
+          "ko": "폴링 간격(초)",
+          "ar": "معدل الاستطلاع (بالثواني)"
         }
       },
       {
@@ -44,7 +54,18 @@
         "type": "label",
         "label": {
           "en": "External changes, such as using the Xiaomi app or the physical knob, are detected after the next polling interval.",
-          "nl": "Externe wijzigingen, zoals via de Xiaomi-app of de fysieke knop, worden na het volgende polling-interval gedetecteerd."
+          "nl": "Externe wijzigingen, zoals via de Xiaomi-app of de fysieke knop, worden na het volgende polling-interval gedetecteerd.",
+          "da": "Eksterne ændringer, f.eks. via Xiaomi-appen eller den fysiske drejeknap, registreres efter næste pollinginterval.",
+          "de": "Externe Änderungen, z. B. über die Xiaomi-App oder den physischen Drehknopf, werden nach dem nächsten Abfrageintervall erkannt.",
+          "es": "Los cambios externos, como usar la app de Xiaomi o el mando físico, se detectan después del siguiente intervalo de sondeo.",
+          "fr": "Les changements externes, comme l’utilisation de l’application Xiaomi ou du bouton physique, sont détectés après le prochain intervalle d’interrogation.",
+          "it": "Le modifiche esterne, ad esempio tramite l’app Xiaomi o la manopola fisica, vengono rilevate dopo il successivo intervallo di polling.",
+          "no": "Eksterne endringer, for eksempel via Xiaomi-appen eller den fysiske knotten, oppdages etter neste pollingintervall.",
+          "sv": "Externa ändringar, till exempel via Xiaomi-appen eller den fysiska ratten, upptäcks efter nästa pollningsintervall.",
+          "pl": "Zmiany zewnętrzne, takie jak użycie aplikacji Xiaomi lub fizycznego pokrętła, są wykrywane po następnym interwale odpytywania.",
+          "ru": "Внешние изменения, например через приложение Xiaomi или физическую ручку, обнаруживаются после следующего интервала опроса.",
+          "ko": "Xiaomi 앱이나 물리적 노브를 통한 외부 변경은 다음 폴링 간격 이후에 감지됩니다.",
+          "ar": "يتم اكتشاف التغييرات الخارجية، مثل استخدام تطبيق Xiaomi أو المقبض الفعلي، بعد فترة الاستطلاع التالية."
         },
         "value": ""
       }


### PR DESCRIPTION
This PR adds missing supported Homey translations for the Xiaomi Monitor Light Bar S1 and Yeelight Color Bulb drivers, flow cards, and settings. The translations are generated with AI.

 No device behavior was changed.

 Validation:
  - `homey app validate` passes at publish level
  - checked that the edited translation objects include Homey's supported language keys
  - `homey app run --remote` to confirm the app starts without crashing

 I have not manually verified every language in the Homey UI, so this is probably best suited for the test channel first.

 If you do not like or trust these AI-generated translations, feel free to decline this PR. No hard feelings.

 Keep up the good work!