### PR TITLE
Scoped ricecooker and washer trigger cards to device level

### DIFF
--- a/.homeycompose/flow/triggers/ricecookerFault.json
+++ b/.homeycompose/flow/triggers/ricecookerFault.json
@@ -14,6 +14,13 @@
       "example": "Bottom temperature sensor fault"
     }
   ],
+  "args": [
+    {
+      "name": "device",
+      "type": "device",
+      "filter": "driver_id=ricecooker_chunmi_cooker_r2"
+    }
+  ],
   "platforms": [
     "local"
   ]

--- a/.homeycompose/flow/triggers/ricecookerFinished.json
+++ b/.homeycompose/flow/triggers/ricecookerFinished.json
@@ -3,6 +3,13 @@
     "en": "Cooking finished",
     "nl": "Koken is voltooid"
   },
+  "args": [
+    {
+      "name": "device",
+      "type": "device",
+      "filter": "driver_id=ricecooker_chunmi_cooker_r2"
+    }
+  ],
   "platforms": [
     "local"
   ]

--- a/.homeycompose/flow/triggers/ricecookerStarted.json
+++ b/.homeycompose/flow/triggers/ricecookerStarted.json
@@ -3,6 +3,13 @@
     "en": "Cooking started",
     "nl": "Koken is gestart"
   },
+  "args": [
+    {
+      "name": "device",
+      "type": "device",
+      "filter": "driver_id=ricecooker_chunmi_cooker_r2"
+    }
+  ],
   "platforms": [
     "local"
   ]

--- a/.homeycompose/flow/triggers/washerFinished.json
+++ b/.homeycompose/flow/triggers/washerFinished.json
@@ -3,6 +3,13 @@
     "en": "Washing program finished",
     "nl": "Wasprogramma is klaar"
   },
+  "args": [
+    {
+      "name": "device",
+      "type": "device",
+      "filter": "driver_id=washer"
+    }
+  ],
   "platforms": [
     "local"
   ]

--- a/.homeycompose/flow/triggers/washerStarted.json
+++ b/.homeycompose/flow/triggers/washerStarted.json
@@ -3,6 +3,13 @@
     "en": "Washing program started",
     "nl": "Wasprogramma is gestart"
   },
+  "args": [
+    {
+      "name": "device",
+      "type": "device",
+      "filter": "driver_id=washer"
+    }
+  ],
   "platforms": [
     "local"
   ]


### PR DESCRIPTION
## Summary
Fix trigger cards for `ricecookerStarted`, `ricecookerFinished`, `ricecookerFault`, `washerStarted` and `washerFinished` that appeared in the flow editor for all users regardless of whether they own those devices.
The missing `device` arg caused them to be registered at app scope instead of device scope.

## Compatibility
All five trigger card flows will need to be recreated (card signature changed).
Before this fix the cards triggered for every device instance with no way to distinguish between them.

## Validation
- homey app validate

## Test
- Tested that unsupported trigger cards are not visible at app scope level.
- Not tested on devices, since I do not own any of them.