### PR TITLE
Add Mijia Smart Air Purifier 6 support

### DIFF
--- a/app.json
+++ b/app.json
@@ -16423,6 +16423,24 @@
             "ja": "イオンを有効にする",
             "zh": "启用离子"
           }
+        },
+        "onoff.uv": {
+          "title": {
+            "en": "Enable UV lamp",
+            "nl": "UV-lamp inschakelen",
+            "da": "Aktiver UV-lampe",
+            "de": "UV-Lampe aktivieren",
+            "es": "Activar lámpara UV",
+            "fr": "Activer la lampe UV",
+            "it": "Attiva lampada UV",
+            "no": "Aktiver UV-lampe",
+            "sv": "Aktivera UV-lampa",
+            "pl": "Włącz lampę UV",
+            "ru": "Включить УФ-лампу",
+            "ko": "UV 램프 활성화",
+            "ja": "UVランプを有効にする",
+            "zh": "启用紫外线灯"
+          }
         }
       },
       "id": "airpurifier_zhimi_advanced_miot",

--- a/drivers/airpurifier_zhimi_advanced_miot/device.js
+++ b/drivers/airpurifier_zhimi_advanced_miot/device.js
@@ -3,6 +3,9 @@
 const Homey = require('homey');
 const Device = require('../wifi_device.js');
 const Util = require('../../lib/util.js');
+const AirPurifierMiot = require('../../lib/airpurifier-zhimi-miot.js');
+
+const xiaomiMb5Profile = AirPurifierMiot.getModelProfile('xiaomi.airp.mb5');
 
 /* supported devices */
 // https://home.miot-spec.com/spec/zhimi.airpurifier.ma4 // Airpurifier 3
@@ -24,6 +27,7 @@ const Util = require('../../lib/util.js');
 // https://home.miot-spec.com/spec/zhimi.airp.meb1 // Xiaomi Smart Air Purifier Elite
 // https://home.miot-spec.com/spec/xiaomi.airp.cpa4 // Xiaomi Smart Air Purifier 4 Compact
 // https://home.miot-spec.com/spec/zhimi.airp.cpa4 // Xiaomi Smart Air Purifier 4 Compact
+// https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:air-purifier:0000A007:xiaomi-mb5:1:0000D050 // Mijia Smart Air Purifier 6
 
 const mapping = {
   "zhimi.airpurifier.ma4": "mapping_default", 
@@ -45,6 +49,7 @@ const mapping = {
   "zhimi.airp.meb1": "mapping_airp_meb1",
   "xiaomi.airp.cpa4": "mapping_cpa4",
   "zhimi.airp.cpa4": "mapping_cpa4",
+  "xiaomi.airp.mb5": xiaomiMb5Profile.mapping,
   "zhimi.airpurifier.*": "mapping_default",
 };
 
@@ -303,6 +308,7 @@ const properties = {
       "light": { "min": 0, "max": 2 }
     }
   },
+  [xiaomiMb5Profile.mapping]: xiaomiMb5Profile.properties
 }
 
 const modes = {
@@ -317,20 +323,24 @@ class AdvancedMiAirPurifierMiotDevice extends Device {
   async onInit() {
     try {
       if (!this.util) this.util = new Util({homey: this.homey});
-      
-      // GENERIC DEVICE INIT ACTIONS
-      this.bootSequence();
-
-      // ADD DEVICES DEPENDANT CAPABILITIES
-      if (cpa4Models.includes(this.getStoreValue('model')) && this.hasCapability('airpurifier_zhimi_fanlevel')) {
-        this.removeCapability('airpurifier_zhimi_fanlevel');
-      }
-      if (cpa4Models.includes(this.getStoreValue('model')) && !this.hasCapability('airpurifier_xiaomi_fanlevel')) {
-        this.addCapability('airpurifier_xiaomi_fanlevel');
-      }
 
       // DEVICE VARIABLES
-      this.deviceProperties = properties[mapping[this.getStoreValue('model')]] !== undefined ? properties[mapping[this.getStoreValue('model')]] : properties[mapping['zhimi.airpurifier.*']];
+      const model = this.getStoreValue('model');
+      this.modelProfile = AirPurifierMiot.getModelProfile(model);
+      const mappingId = this.modelProfile?.mapping || mapping[model] || mapping['zhimi.airpurifier.*'];
+      this.deviceProperties = properties[mappingId];
+
+      // ADD DEVICES DEPENDANT CAPABILITIES
+      if (cpa4Models.includes(model) && this.hasCapability('airpurifier_zhimi_fanlevel')) {
+        await this.removeCapability('airpurifier_zhimi_fanlevel');
+      }
+      if (cpa4Models.includes(model) && !this.hasCapability('airpurifier_xiaomi_fanlevel')) {
+        await this.addCapability('airpurifier_xiaomi_fanlevel');
+      }
+      await this.addOptionalCapabilities();
+
+      // GENERIC DEVICE INIT ACTIONS
+      this.bootSequence();
 
       // FLOW TRIGGER CARDS
       this.homey.flow.getDeviceTriggerCard('triggerModeChanged');
@@ -351,25 +361,14 @@ class AdvancedMiAirPurifierMiotDevice extends Device {
         }
       });
 
-      this.registerCapabilityListener('onoff.ion', async (value) => {
-        try {
-          if (this.miio) {
-            return await this.miio.call("set_properties", [{ siid: this.deviceProperties.set_properties.ion.siid, piid: this.deviceProperties.set_properties.power.ion, value: value }], { retries: 1 });
-          } else {
-            this.setUnavailable(this.homey.__('unreachable')).catch(error => { this.error(error) });
-            this.createDevice();
-            return Promise.reject('Device unreachable, please try again ...');
-          }
-        } catch (error) {
-          this.error(error);
-          return Promise.reject(error);
-        }
-      });
+      this.registerOptionalBooleanCapabilityListener('onoff.ion', 'ion');
+      this.registerOptionalBooleanCapabilityListener('onoff.uv', 'uv');
 
       this.registerCapabilityListener('airpurifier_zhimi_fanlevel', async (value) => {
         try {
           if (this.miio) {
-            return await this.miio.call("set_properties", [{ siid: this.deviceProperties.set_properties.fanlevel.siid, piid: this.deviceProperties.set_properties.fanlevel.piid, value: +value }], { retries: 1 });
+            const deviceValue = AirPurifierMiot.encodeValue(this.modelProfile, 'fanlevel', value);
+            return await this.miio.call("set_properties", [{ siid: this.deviceProperties.set_properties.fanlevel.siid, piid: this.deviceProperties.set_properties.fanlevel.piid, value: deviceValue }], { retries: 1 });
           } else {
             this.setUnavailable(this.homey.__('unreachable')).catch(error => { this.error(error) });
             this.createDevice();
@@ -384,7 +383,8 @@ class AdvancedMiAirPurifierMiotDevice extends Device {
       this.registerCapabilityListener('airpurifier_xiaomi_fanlevel', async (value) => {
         try {
           if (this.miio) {
-            return await this.miio.call("set_properties", [{ siid: this.deviceProperties.set_properties.fanlevel.siid, piid: this.deviceProperties.set_properties.fanlevel.piid, value: +value }], { retries: 1 });
+            const deviceValue = AirPurifierMiot.encodeValue(this.modelProfile, 'fanlevel', value);
+            return await this.miio.call("set_properties", [{ siid: this.deviceProperties.set_properties.fanlevel.siid, piid: this.deviceProperties.set_properties.fanlevel.piid, value: deviceValue }], { retries: 1 });
           } else {
             this.setUnavailable(this.homey.__('unreachable')).catch(error => { this.error(error) });
             this.createDevice();
@@ -399,8 +399,8 @@ class AdvancedMiAirPurifierMiotDevice extends Device {
       this.registerCapabilityListener('airpurifier_zhimi_mode', async (value) => {
         try {
           if (this.miio) {
-            const mode = modes[value];
-            return await this.miio.call("set_properties", [{ siid: this.deviceProperties.set_properties.mode.siid, piid: this.deviceProperties.set_properties.mode.piid, value: +value }], { retries: 1 });
+            const deviceValue = AirPurifierMiot.encodeValue(this.modelProfile, 'mode', value);
+            return await this.miio.call("set_properties", [{ siid: this.deviceProperties.set_properties.mode.siid, piid: this.deviceProperties.set_properties.mode.piid, value: deviceValue }], { retries: 1 });
           } else {
             this.setUnavailable(this.homey.__('unreachable')).catch(error => { this.error(error) });
             this.createDevice();
@@ -415,6 +415,34 @@ class AdvancedMiAirPurifierMiotDevice extends Device {
     } catch (error) {
       this.error(error);
     }
+  }
+
+  async addOptionalCapabilities() {
+    for (const optionalCapability of AirPurifierMiot.getOptionalCapabilities(this.deviceProperties)) {
+      if (!this.hasCapability(optionalCapability.capability)) {
+        await this.addCapability(optionalCapability.capability);
+      }
+    }
+  }
+
+  registerOptionalBooleanCapabilityListener(capability, property) {
+    const propertyDefinition = this.deviceProperties.set_properties[property];
+    if (!propertyDefinition || !this.hasCapability(capability)) return;
+
+    this.registerCapabilityListener(capability, async (value) => {
+      try {
+        if (this.miio) {
+          return await this.miio.call("set_properties", [{ siid: propertyDefinition.siid, piid: propertyDefinition.piid, value }], { retries: 1 });
+        }
+
+        this.setUnavailable(this.homey.__('unreachable')).catch(error => { this.error(error) });
+        this.createDevice();
+        return Promise.reject('Device unreachable, please try again ...');
+      } catch (error) {
+        this.error(error);
+        return Promise.reject(error);
+      }
+    });
   }
 
   async onSettings({ oldSettings, newSettings, changedKeys }) {
@@ -449,7 +477,8 @@ class AdvancedMiAirPurifierMiotDevice extends Device {
       const measure_humidity = result.find(obj => obj.did === 'humidity');
       const measure_temperature = result.find(obj => obj.did === 'temperature');
       const measure_pm25 = result.find(obj => obj.did === 'aqi');
-      const onoff_ion = result.find(obj => obj.did === 'anion');
+      const onoff_ion = AirPurifierMiot.findValidResult(result, 'anion');
+      const onoff_uv = AirPurifierMiot.findValidResult(result, 'uv');
 
       const buzzer = result.find(obj => obj.did === 'buzzer');
       const child_lock = result.find(obj => obj.did === 'child_lock');
@@ -471,6 +500,9 @@ class AdvancedMiAirPurifierMiotDevice extends Device {
       if (onoff_ion !== undefined) {
         await this.updateCapabilityValue("onoff.ion", onoff_ion.value);
       }
+      if (onoff_uv !== undefined) {
+        await this.updateCapabilityValue("onoff.uv", onoff_uv.value);
+      }
 
       /* settings */
       await this.updateSettingValue("led", led.value === this.deviceProperties.device_properties.light.min ? false : true);
@@ -485,18 +517,22 @@ class AdvancedMiAirPurifierMiotDevice extends Device {
       }
 
       /* mode capability */
-      const mode = result.find(obj => obj.did === 'mode');
-      if (this.getCapabilityValue('airpurifier_zhimi_mode') !== mode.value.toString()) {
+      const mode = AirPurifierMiot.findValidResult(result, 'mode');
+      const homeyMode = mode === undefined ? undefined : AirPurifierMiot.decodeValue(this.modelProfile, 'mode', mode.value);
+      if (homeyMode !== undefined && this.getCapabilityValue('airpurifier_zhimi_mode') !== homeyMode) {
         const previous_mode = this.getCapabilityValue('airpurifier_zhimi_mode');
-        await this.setCapabilityValue('airpurifier_zhimi_mode', mode.value.toString());
-        await this.homey.flow.getDeviceTriggerCard('triggerModeChanged').trigger(this, {"new_mode": modes[mode.value], "previous_mode": modes[+previous_mode] }).catch(error => { this.error(error) });
+        await this.setCapabilityValue('airpurifier_zhimi_mode', homeyMode);
+        await this.homey.flow.getDeviceTriggerCard('triggerModeChanged').trigger(this, {"new_mode": modes[+homeyMode], "previous_mode": modes[+previous_mode] }).catch(error => { this.error(error) });
       }
 
       /* device specific settings */
       if (cpa4Models.includes(this.getStoreValue('model')) && fanlevel !== undefined) {
         await this.updateCapabilityValue("airpurifier_xiaomi_fanlevel", Number(fanlevel.value));
       } else if (fanlevel !== undefined) {
-        await this.updateCapabilityValue("airpurifier_zhimi_fanlevel", fanlevel.value.toString());
+        const homeyFanlevel = AirPurifierMiot.decodeValue(this.modelProfile, 'fanlevel', fanlevel.value);
+        if (homeyFanlevel !== undefined) {
+          await this.updateCapabilityValue("airpurifier_zhimi_fanlevel", homeyFanlevel);
+        }
       }
 
     } catch (error) {

--- a/drivers/airpurifier_zhimi_advanced_miot/driver.compose.json
+++ b/drivers/airpurifier_zhimi_advanced_miot/driver.compose.json
@@ -46,6 +46,24 @@
         "ja": "イオンを有効にする",
         "zh": "启用离子"
       }
+    },
+    "onoff.uv": {
+      "title": {
+        "en": "Enable UV lamp",
+        "nl": "UV-lamp inschakelen",
+        "da": "Aktiver UV-lampe",
+        "de": "UV-Lampe aktivieren",
+        "es": "Activar lámpara UV",
+        "fr": "Activer la lampe UV",
+        "it": "Attiva lampada UV",
+        "no": "Aktiver UV-lampe",
+        "sv": "Aktivera UV-lampa",
+        "pl": "Włącz lampę UV",
+        "ru": "Включить УФ-лампу",
+        "ko": "UV 램프 활성화",
+        "ja": "UVランプを有効にする",
+        "zh": "启用紫外线灯"
+      }
     }
   }
 }

--- a/lib/airpurifier-zhimi-miot.js
+++ b/lib/airpurifier-zhimi-miot.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const MODEL_PROFILES = {
+  'xiaomi.airp.mb5': {
+    mapping: 'mapping_xiaomi_mb5',
+    properties: {
+      get_properties: [
+        { did: 'power', siid: 2, piid: 1 },
+        { did: 'fanlevel', siid: 2, piid: 5 },
+        { did: 'mode', siid: 2, piid: 4 },
+        { did: 'humidity', siid: 3, piid: 1 },
+        { did: 'temperature', siid: 3, piid: 7 },
+        { did: 'aqi', siid: 3, piid: 4 },
+        { did: 'anion', siid: 2, piid: 6 },
+        { did: 'uv', siid: 2, piid: 7 },
+        { did: 'buzzer', siid: 6, piid: 1 },
+        { did: 'child_lock', siid: 8, piid: 1 },
+        { did: 'light', siid: 7, piid: 1 },
+        { did: 'filter_life_remaining', siid: 4, piid: 1 },
+        { did: 'filter_hours_used', siid: 4, piid: 3 }
+      ],
+      set_properties: {
+        power: { siid: 2, piid: 1 },
+        ion: { siid: 2, piid: 6 },
+        uv: { siid: 2, piid: 7 },
+        fanlevel: { siid: 2, piid: 5 },
+        mode: { siid: 2, piid: 4 },
+        buzzer: { siid: 6, piid: 1 },
+        child_lock: { siid: 8, piid: 1 },
+        light: { siid: 7, piid: 1 }
+      },
+      device_properties: {
+        light: { min: false, max: true }
+      }
+    },
+    value_maps: {
+      mode: {
+        to_device: { 0: 0, 1: 3, 2: 5, 3: 6 },
+        from_device: { 0: '0', 3: '1', 5: '2', 6: '3' }
+      },
+      fanlevel: {
+        to_device: { 1: 0, 2: 1, 3: 2 },
+        from_device: { 0: '1', 1: '2', 2: '3' }
+      }
+    }
+  }
+};
+
+const OPTIONAL_CAPABILITIES = [
+  { capability: 'onoff.ion', property: 'ion', did: 'anion' },
+  { capability: 'onoff.uv', property: 'uv', did: 'uv' }
+];
+
+function getModelProfile(model) {
+  return MODEL_PROFILES[model];
+}
+
+function encodeValue(profile, property, value) {
+  const valueMap = profile?.value_maps?.[property]?.to_device;
+  if (!valueMap) return Number(value);
+
+  const key = String(value);
+  if (!Object.prototype.hasOwnProperty.call(valueMap, key)) {
+    throw new Error(`Unsupported ${property} value: ${value}`);
+  }
+  return valueMap[key];
+}
+
+function decodeValue(profile, property, value) {
+  const valueMap = profile?.value_maps?.[property]?.from_device;
+  if (!valueMap) return String(value);
+
+  const key = String(value);
+  return Object.prototype.hasOwnProperty.call(valueMap, key) ? valueMap[key] : undefined;
+}
+
+function findValidResult(result, did) {
+  return result.find((entry) => entry.did === did
+    && (entry.code === undefined || entry.code === 0)
+    && entry.value !== undefined
+    && entry.value !== null);
+}
+
+function getOptionalCapabilities(properties) {
+  return OPTIONAL_CAPABILITIES.filter(({ property, did }) => properties.get_properties.some((entry) => entry.did === did)
+    && properties.set_properties[property] !== undefined);
+}
+
+module.exports = {
+  MODEL_PROFILES,
+  getModelProfile,
+  encodeValue,
+  decodeValue,
+  findValidResult,
+  getOptionalCapabilities
+};

--- a/test/airpurifier-zhimi-miot.test.js
+++ b/test/airpurifier-zhimi-miot.test.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  getModelProfile,
+  encodeValue,
+  decodeValue,
+  findValidResult,
+  getOptionalCapabilities
+} = require('../lib/airpurifier-zhimi-miot.js');
+
+const driverCompose = require('../drivers/airpurifier_zhimi_advanced_miot/driver.compose.json');
+
+const profile = getModelProfile('xiaomi.airp.mb5');
+
+test('xiaomi.airp.mb5 uses its released MIoT property layout', () => {
+  assert.ok(profile);
+
+  const readable = Object.fromEntries(profile.properties.get_properties.map(({ did, siid, piid }) => [did, { siid, piid }]));
+  assert.deepEqual(readable, {
+    power: { siid: 2, piid: 1 },
+    fanlevel: { siid: 2, piid: 5 },
+    mode: { siid: 2, piid: 4 },
+    humidity: { siid: 3, piid: 1 },
+    temperature: { siid: 3, piid: 7 },
+    aqi: { siid: 3, piid: 4 },
+    anion: { siid: 2, piid: 6 },
+    uv: { siid: 2, piid: 7 },
+    buzzer: { siid: 6, piid: 1 },
+    child_lock: { siid: 8, piid: 1 },
+    light: { siid: 7, piid: 1 },
+    filter_life_remaining: { siid: 4, piid: 1 },
+    filter_hours_used: { siid: 4, piid: 3 }
+  });
+  assert.equal(readable.purify_volume, undefined, 'the MB5 spec has no purify-volume property');
+
+  assert.deepEqual(profile.properties.set_properties.buzzer, { siid: 6, piid: 1 });
+  assert.deepEqual(profile.properties.set_properties.light, { siid: 7, piid: 1 });
+});
+
+test('xiaomi.airp.mb5 mode values round-trip through the existing Homey capability IDs', () => {
+  const expected = new Map([
+    ['0', 0],
+    ['1', 3],
+    ['2', 5],
+    ['3', 6]
+  ]);
+
+  for (const [homeyValue, deviceValue] of expected) {
+    assert.equal(encodeValue(profile, 'mode', homeyValue), deviceValue);
+    assert.equal(decodeValue(profile, 'mode', deviceValue), homeyValue);
+  }
+});
+
+test('xiaomi.airp.mb5 zero-based fan levels round-trip through the legacy 1-based capability', () => {
+  const expected = new Map([
+    ['1', 0],
+    ['2', 1],
+    ['3', 2]
+  ]);
+
+  for (const [homeyValue, deviceValue] of expected) {
+    assert.equal(encodeValue(profile, 'fanlevel', homeyValue), deviceValue);
+    assert.equal(decodeValue(profile, 'fanlevel', deviceValue), homeyValue);
+  }
+});
+
+test('unknown enum values are rejected instead of being written to Homey or the purifier', () => {
+  assert.throws(() => encodeValue(profile, 'mode', '4'), /Unsupported mode value/);
+  assert.throws(() => encodeValue(profile, 'fanlevel', '0'), /Unsupported fanlevel value/);
+  assert.equal(decodeValue(profile, 'mode', 1), undefined);
+  assert.equal(decodeValue(profile, 'fanlevel', 3), undefined);
+});
+
+test('optional MIoT properties ignore failed and empty results', () => {
+  const result = [
+    { did: 'anion', code: -4004 },
+    { did: 'uv', code: 0, value: null },
+    { did: 'mode', code: 0, value: 3 }
+  ];
+
+  assert.equal(findValidResult(result, 'anion'), undefined);
+  assert.equal(findValidResult(result, 'uv'), undefined);
+  assert.deepEqual(findValidResult(result, 'mode'), { did: 'mode', code: 0, value: 3 });
+});
+
+test('ion and UV remain model-specific instead of becoming default driver capabilities', () => {
+  assert.deepEqual(getOptionalCapabilities(profile.properties).map(({ capability }) => capability), ['onoff.ion', 'onoff.uv']);
+  assert.ok(!driverCompose.capabilities.includes('onoff.ion'));
+  assert.ok(!driverCompose.capabilities.includes('onoff.uv'));
+  assert.ok(driverCompose.capabilitiesOptions['onoff.ion']);
+  assert.ok(driverCompose.capabilitiesOptions['onoff.uv']);
+
+  const unsupportedProperties = {
+    get_properties: [{ did: 'power', siid: 2, piid: 1 }],
+    set_properties: { power: { siid: 2, piid: 1 } }
+  };
+  assert.deepEqual(getOptionalCapabilities(unsupportedProperties), []);
+});


### PR DESCRIPTION
## What changed
- add a dedicated `xiaomi.airp.mb5` MIoT profile using Xiaomi's released schema
- translate its mode (`0/3/5/6`) and fan-level (`0/1/2`) values to the existing Homey capability IDs
- add ion and UV only when the selected model exposes them
- fix the existing ion setter PIID lookup
- add regression coverage for mappings and capability scope

## Why
The model connected locally but fell back to the generic purifier map. It shares some SIID/PIID locations with the VA2 family, but its enum values, display service, buzzer setter, and available properties differ, so the shared mapping from #334 was not safe.

## Validation
- `node --check drivers/airpurifier_zhimi_advanced_miot/device.js`
- `node --check lib/airpurifier-zhimi-miot.js`
- `npm test` (18 passed)
- `homey app validate` (publish level)
- `git diff --check`

Runtime control still requires confirmation on a physical `xiaomi.airp.mb5` using the Test app.

Fixes #333