### PR TITLE
Refresh vacuum rooms before advanced room cleaning

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -595,5 +595,8 @@
   },
   "3.5.19": {
     "en": "Added X20 Max Flow cards for raw robot and base-station status changes"
+  },
+  "3.5.20": {
+    "en": "Advanced Room Cleaning now resolves against a fresh room map, with credits to @odheas-prog."
   }
 }

--- a/drivers/vacuum_xiaomi_vacuum_max/device.js
+++ b/drivers/vacuum_xiaomi_vacuum_max/device.js
@@ -760,29 +760,23 @@ class XiaomiVacuumMiotDeviceMax extends Device {
                 if (!args.device || !args.device.deviceProperties || !args.device.deviceProperties.supports.rooms || !args.device.deviceProperties.set_properties.room_clean_action) {
                     return Promise.reject('Room cleaning is not supported by this device.');
                 }
-                const rawRooms = args.device.getSetting('rooms');
-                let list_room = [];
+                // Room IDs can change after editing the map in Xiaomi Home.
+                // Always ask the vacuum for its current room map immediately before
+                // resolving the Flow room argument. Keep the cached list only as a
+                // fallback if that optional refresh fails.
+                const cachedRooms = args.device._parseRoomsSetting(args.device.getSetting('rooms'));
+                let list_room = cachedRooms;
+
                 try {
-                    if (Array.isArray(rawRooms)) {
-                        list_room = rawRooms;
-                    } else if (typeof rawRooms === 'string') {
-                        try {
-                            list_room = JSON.parse(rawRooms);
-                        } catch (_) {
-                            try {
-                                list_room = JSON.parse(rawRooms.replace(/\\"/g, '"'));
-                            } catch (_) {
-                                if (rawRooms.startsWith('"') && rawRooms.endsWith('"')) {
-                                    list_room = JSON.parse(JSON.parse(rawRooms));
-                                }
-                            }
-                        }
-                    }
-                } catch (e) {
-                    this.error('Rooms list in settings is invalid/missing.', e);
-                    return Promise.reject('Room list is not available. Please sync device first.');
+                    const refreshedRooms = await args.device._refreshRoomsBeforeCleaning();
+                    if (refreshedRooms.length) list_room = refreshedRooms;
+                } catch (error) {
+                    args.device.error(
+                        '[ROOMS] Refresh before room clean failed: ' +
+                        args.device._getSafeErrorDetails(error) +
+                        '; using cached room list.'
+                    );
                 }
-                if (!Array.isArray(list_room)) list_room = [];
 
                 let selected_ids;
                 if (args.room === 'all') {
@@ -793,7 +787,73 @@ class XiaomiVacuumMiotDeviceMax extends Device {
                         const token = rawToken.trim();
                         if (!token) continue;
                         if (/^\d+$/.test(token)) {
-                            selected_ids.push(Number(token));
+                            const requestedId = Number(token);
+                            const oldRoom = cachedRooms.find(
+                                (room) => Number(room.id) === requestedId
+                            );
+                            const exactCurrentRoom = list_room.find(
+                                (room) => Number(room.id) === requestedId
+                            );
+
+                            // A numeric room ID may still exist after a Xiaomi map
+                            // edit but now belong to a different room. When we have
+                            // cached semantic information for that old ID, compare
+                            // the room name before trusting the numeric match.
+                            if (oldRoom && oldRoom.name) {
+                                const oldName = String(oldRoom.name).trim().toLowerCase();
+                                const exactCurrentName = exactCurrentRoom
+                                    ? String(exactCurrentRoom.name || '').trim().toLowerCase()
+                                    : '';
+
+                                if (exactCurrentRoom && exactCurrentName === oldName) {
+                                    selected_ids.push(Number(exactCurrentRoom.id));
+                                    continue;
+                                }
+
+                                const replacements = list_room.filter(
+                                    (room) =>
+                                        String(room.name || '').trim().toLowerCase() === oldName
+                                );
+
+                                if (replacements.length === 1) {
+                                    const replacementId = Number(replacements[0].id);
+                                    selected_ids.push(replacementId);
+
+                                    if (replacementId !== requestedId) {
+                                        args.device.log(
+                                            '[ROOMS] Remapped stale room id ' +
+                                            requestedId +
+                                            ' (' +
+                                            oldRoom.name +
+                                            ') -> ' +
+                                            replacementId
+                                        );
+                                    }
+                                    continue;
+                                }
+
+                                args.device.log(
+                                    '[ROOMS] Stale room id ' +
+                                    requestedId +
+                                    ' (' +
+                                    oldRoom.name +
+                                    ') could not be resolved uniquely in the current room map.'
+                                );
+                                continue;
+                            }
+
+                            // No cached meaning is known for this numeric ID, so a
+                            // currently existing ID can still be used as entered.
+                            if (exactCurrentRoom) {
+                                selected_ids.push(Number(exactCurrentRoom.id));
+                                continue;
+                            }
+
+                            args.device.log(
+                                '[ROOMS] Requested numeric room id ' +
+                                requestedId +
+                                ' is not present in the current room map.'
+                            );
                             continue;
                         }
                         const name = token.toLowerCase();
@@ -802,8 +862,20 @@ class XiaomiVacuumMiotDeviceMax extends Device {
                     }
                 }
 
+                selected_ids = Array.from(
+                    new Set(
+                        selected_ids
+                            .map((id) => Number(id))
+                            .filter((id) => Number.isFinite(id))
+                    )
+                );
+
                 if (!selected_ids.length) {
-                    return Promise.reject(`No valid room selected. Requested: "${args.room}". Available: ${list_room.map((r) => r.name).join(', ')}.`);
+                    return Promise.reject(
+                        `No valid CURRENT room selected. Requested: "${args.room}". Available: ${list_room
+                            .map((room) => (room.name || ('Room ' + room.id)) + ' [' + room.id + ']')
+                            .join(', ')}.`
+                    );
                 }
 
                 const room_list = args.device._serializeRoomList(selected_ids);
@@ -1601,6 +1673,184 @@ class XiaomiVacuumMiotDeviceMax extends Device {
             .join(', ');
     }
 
+
+    _normalizeRoomList(rooms) {
+        if (!Array.isArray(rooms)) return [];
+
+        return rooms
+            .filter((room) => room && typeof room === 'object' && room.id != null)
+            .map((room) => {
+                const id = Number(room.id);
+                if (!Number.isFinite(id)) return null;
+
+                const name =
+                    typeof room.name === 'string' && room.name.trim()
+                        ? room.name.trim()
+                        : 'Room ' + id;
+
+                return {
+                    ...room,
+                    id,
+                    name
+                };
+            })
+            .filter(Boolean);
+    }
+
+    _parseRoomsSetting(rawRooms) {
+        let value = rawRooms;
+
+        for (let depth = 0; depth < 3 && typeof value === 'string'; depth += 1) {
+            const text = value.trim();
+            if (!text) return [];
+
+            try {
+                value = JSON.parse(text);
+            } catch (_) {
+                try {
+                    value = JSON.parse(text.replace(/\\\"/g, '"'));
+                } catch (_) {
+                    return [];
+                }
+            }
+        }
+
+        return this._normalizeRoomList(value);
+    }
+
+    _parseRoomsPayload(rawValue) {
+        let parsed = rawValue;
+
+        for (let depth = 0; depth < 3 && typeof parsed === 'string'; depth += 1) {
+            const text = parsed.trim();
+            if (!text) return [];
+
+            try {
+                parsed = JSON.parse(text);
+            } catch (_) {
+                try {
+                    parsed = JSON.parse(text.replace(/\\\"/g, '"'));
+                } catch (_) {
+                    return [];
+                }
+            }
+        }
+
+        let rooms = [];
+
+        if (parsed && Array.isArray(parsed.rooms)) {
+            rooms = parsed.rooms;
+        } else if (parsed && Array.isArray(parsed.sections)) {
+            rooms = parsed.sections;
+        } else if (Array.isArray(parsed)) {
+            rooms = parsed.filter((room) => room && typeof room === 'object' && room.id != null);
+        } else if (parsed && Array.isArray(parsed.selects)) {
+            const ids = Array.from(
+                new Set(
+                    parsed.selects
+                        .flat()
+                        .map((id) => Number(id))
+                        .filter((id) => Number.isFinite(id))
+                )
+            );
+            rooms = ids.map((id) => ({ id, name: 'Room ' + id }));
+        }
+
+        return this._normalizeRoomList(rooms);
+    }
+
+    _roomListSignature(rooms) {
+        return this._normalizeRoomList(rooms)
+            .map((room) => ({
+                id: Number(room.id),
+                name: String(room.name || '')
+            }))
+            .sort((a, b) => a.id - b.id || a.name.localeCompare(b.name))
+            .map((room) => room.id + ':' + room.name)
+            .join('|');
+    }
+
+    async _refreshRoomsBeforeCleaning() {
+        if (
+            !this.deviceProperties ||
+            !this.deviceProperties.supports ||
+            !this.deviceProperties.supports.rooms
+        ) {
+            return [];
+        }
+
+        const candidates = [];
+
+        if (
+            Array.isArray(this.deviceProperties.get_rooms) &&
+            this.deviceProperties.get_rooms.length
+        ) {
+            candidates.push(this.deviceProperties.get_rooms);
+        }
+
+        // Existing fallback locations retained from the 3.5.19 discovery code.
+        candidates.push(
+            [{ did: 'rooms', siid: 4, piid: 20 }],
+            [{ did: 'rooms', siid: 6, piid: 15 }],
+            [{ did: 'rooms', siid: 7, piid: 3 }]
+        );
+
+        let lastError = null;
+
+        for (const definition of candidates) {
+            try {
+                const result = await this.callVacuumGetProperties(definition, { retries: 2 });
+
+                if (
+                    !Array.isArray(result) ||
+                    !result[0] ||
+                    result[0].value == null ||
+                    result[0].value === ''
+                ) {
+                    continue;
+                }
+
+                const rooms = this._parseRoomsPayload(result[0].value);
+                if (!rooms.length) continue;
+
+                const previousRooms = this._parseRoomsSetting(this.getSetting('rooms'));
+                const previousSignature = this._roomListSignature(previousRooms);
+                const newSignature = this._roomListSignature(rooms);
+
+                const settings = {
+                    rooms: JSON.stringify(rooms),
+                    rooms_display: rooms.map((room) => room.name || ('Room ' + room.id)).join(', ')
+                };
+
+                if (
+                    this.getSetting('rooms') !== settings.rooms ||
+                    this.getSetting('rooms_display') !== settings.rooms_display
+                ) {
+                    await this.setSettings(settings);
+                }
+
+                this._roomsDiscovered = true;
+
+                if (previousSignature !== newSignature) {
+                    this.log(
+                        '[ROOMS] Room map refreshed before cleaning: ' +
+                        (previousSignature || '(none)') +
+                        ' -> ' +
+                        newSignature
+                    );
+                } else {
+                    this.log('[ROOMS] Room map checked before cleaning: unchanged.');
+                }
+
+                return rooms;
+            } catch (error) {
+                lastError = error;
+            }
+        }
+
+        if (lastError) throw lastError;
+        throw new Error('No parsable room data returned by the vacuum.');
+    }
 
     getModelIdentifier() {
         return this._model || (this.getStoreValue ? this.getStoreValue('model') : undefined);

--- a/drivers/vacuum_xiaomi_vacuum_max/device.js
+++ b/drivers/vacuum_xiaomi_vacuum_max/device.js
@@ -167,7 +167,9 @@ const GET_PROPERTIES_CHUNK_SIZE = {
 };
 const DEFAULT_GET_PROPERTIES_CHUNK_SIZE = 5;
 const GET_PROPERTIES_CHUNK_DELAY_MS = 100;
-const ROOM_ID_ALIASES_STORE_KEY = 'roomIdAliases';
+const ROOM_ALIAS_STORE_KEY = 'room_id_name_aliases';
+const ROOM_ALIAS_SCHEMA_VERSION = 1;
+const MAX_ROOM_ALIAS_ENTRIES = 64;
 
 /** Property sets */
 const properties = {
@@ -761,67 +763,10 @@ class XiaomiVacuumMiotDeviceMax extends Device {
                 if (!args.device || !args.device.deviceProperties || !args.device.deviceProperties.supports.rooms || !args.device.deviceProperties.set_properties.room_clean_action) {
                     return Promise.reject('Room cleaning is not supported by this device.');
                 }
-                // Room IDs can change after editing the map in Xiaomi Home.
-                // Resolve against a live map when possible, while retaining persistent
-                // old-ID semantics for existing numeric Flow values.
-                const roomState = await args.device._getRoomCleaningState();
-                const cachedRooms = roomState.cachedRooms;
-                const list_room = roomState.rooms;
-                const roomAliases = roomState.aliases;
-
-                let selected_ids;
-                if (args.room === 'all') {
-                    selected_ids = list_room.map((el) => el.id);
-                } else {
-                    selected_ids = [];
-                    for (const rawToken of String(args.room || '').split(',')) {
-                        const token = rawToken.trim();
-                        if (!token) continue;
-                        if (/^\d+$/.test(token)) {
-                            const requestedId = Number(token);
-                            const resolution = args.device._resolveNumericRoomId(
-                                requestedId,
-                                list_room,
-                                cachedRooms,
-                                roomAliases
-                            );
-
-                            if (resolution.id != null) {
-                                selected_ids.push(resolution.id);
-                                if (resolution.remapped) {
-                                    args.device.log(
-                                        '[ROOMS] Remapped stale room id ' +
-                                        requestedId +
-                                        ' (' +
-                                        resolution.name +
-                                        ') -> ' +
-                                        resolution.id
-                                    );
-                                }
-                                continue;
-                            }
-
-                            args.device.log(
-                                '[ROOMS] Numeric room id ' +
-                                requestedId +
-                                ' rejected: ' +
-                                resolution.reason
-                            );
-                            continue;
-                        }
-                        const name = token.toLowerCase();
-                        const match = list_room.find((el) => (el.name || '').toLowerCase() === name);
-                        if (match) selected_ids.push(match.id);
-                    }
-                }
-
-                selected_ids = Array.from(
-                    new Set(
-                        selected_ids
-                            .map((id) => Number(id))
-                            .filter((id) => Number.isFinite(id))
-                    )
-                );
+                const {
+                    rooms: list_room,
+                    selectedIds: selected_ids
+                } = await args.device._resolveAdvancedRoomCleaningSelection(args.room);
 
                 if (!selected_ids.length) {
                     return Promise.reject(
@@ -1627,25 +1572,48 @@ class XiaomiVacuumMiotDeviceMax extends Device {
     }
 
 
-    _normalizeRoomList(rooms) {
+    _isValidRoomId(value) {
+        const id = Number(value);
+        return Number.isSafeInteger(id) && id > 0;
+    }
+
+    _normalizeRoomName(value) {
+        if (typeof value !== 'string') return null;
+        const name = value.trim();
+        return name || null;
+    }
+
+    _roomNameKey(value) {
+        const name = this._normalizeRoomName(value);
+        return name ? name.toLowerCase() : null;
+    }
+
+    _normalizeRoomList(rooms, { fromStoredSetting = false } = {}) {
         if (!Array.isArray(rooms)) return [];
 
         return rooms
             .filter((room) => room && typeof room === 'object' && room.id != null)
             .map((room) => {
                 const id = Number(room.id);
-                if (!Number.isFinite(id)) return null;
+                if (!this._isValidRoomId(id)) return null;
 
-                const name =
-                    typeof room.name === 'string' && room.name.trim()
-                        ? room.name.trim()
-                        : 'Room ' + id;
-
-                return {
+                const suppliedName = this._normalizeRoomName(room.name);
+                const normalizedRoom = {
                     ...room,
                     id,
-                    name
+                    name: suppliedName || ('Room ' + id)
                 };
+
+                // Room maps that only contain an ID get a display label, but that
+                // label must never become a semantic alias for a future map.
+                Object.defineProperty(normalizedRoom, '_hasSemanticRoomName', {
+                    value:
+                        Boolean(suppliedName) &&
+                        (!fromStoredSetting || suppliedName !== ('Room ' + id)),
+                    enumerable: false
+                });
+
+                return normalizedRoom;
             })
             .filter(Boolean);
     }
@@ -1668,7 +1636,7 @@ class XiaomiVacuumMiotDeviceMax extends Device {
             }
         }
 
-        return this._normalizeRoomList(value);
+        return this._normalizeRoomList(value, { fromStoredSetting: true });
     }
 
     _parseRoomsPayload(rawValue) {
@@ -1703,176 +1671,318 @@ class XiaomiVacuumMiotDeviceMax extends Device {
                     parsed.selects
                         .flat()
                         .map((id) => Number(id))
-                        .filter((id) => Number.isFinite(id))
+                        .filter((id) => this._isValidRoomId(id))
                 )
             );
-            rooms = ids.map((id) => ({ id, name: 'Room ' + id }));
+            rooms = ids.map((id) => ({ id }));
         }
 
         return this._normalizeRoomList(rooms);
     }
 
+    _getRoomSettingValue(key) {
+        if (typeof this.getSetting !== 'function') return undefined;
 
-    _roomNameKey(name) {
-        return String(name || '').trim().toLowerCase();
-    }
-
-    _parseRoomIdAliases(rawAliases) {
-        let value = rawAliases;
-        if (typeof value === 'string') {
-            try {
-                value = JSON.parse(value);
-            } catch (_) {
-                return {};
-            }
-        }
-        if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
-
-        const aliases = {};
-        for (const [rawId, rawNames] of Object.entries(value)) {
-            const id = Number(rawId);
-            if (!Number.isFinite(id)) continue;
-            const names = Array.isArray(rawNames) ? rawNames : [rawNames];
-            for (const name of names) this._addRoomIdAlias(aliases, id, name);
-        }
-        return aliases;
-    }
-
-    _addRoomIdAlias(aliases, id, name) {
-        const numericId = Number(id);
-        const displayName = typeof name === 'string' ? name.trim() : '';
-        if (!Number.isFinite(numericId) || !displayName) return;
-
-        const key = String(numericId);
-        if (!Array.isArray(aliases[key])) aliases[key] = [];
-        const canonicalName = this._roomNameKey(displayName);
-        if (!aliases[key].some((existing) => this._roomNameKey(existing) === canonicalName)) {
-            aliases[key].push(displayName);
-        }
-    }
-
-    _mergeRoomIdAliases(previousRooms, currentRooms, rawAliases) {
-        const aliases = this._parseRoomIdAliases(rawAliases);
-        const previous = this._normalizeRoomList(previousRooms);
-        const current = this._normalizeRoomList(currentRooms);
-        const currentById = new Map(current.map((room) => [Number(room.id), room]));
-
-        for (const previousRoom of previous) {
-            const currentRoom = currentById.get(Number(previousRoom.id));
-            if (!currentRoom || this._roomNameKey(currentRoom.name) !== this._roomNameKey(previousRoom.name)) {
-                this._addRoomIdAlias(aliases, previousRoom.id, previousRoom.name);
-                if (currentRoom) this._addRoomIdAlias(aliases, previousRoom.id, currentRoom.name);
-            }
-        }
-
-        // If an ID with historical meaning is later reused, preserve both meanings.
-        // A numeric Flow using that ID is then intentionally rejected as ambiguous.
-        for (const [id, names] of Object.entries({ ...aliases })) {
-            const currentRoom = currentById.get(Number(id));
-            if (!currentRoom) continue;
-            if (names.some((name) => this._roomNameKey(name) !== this._roomNameKey(currentRoom.name))) {
-                this._addRoomIdAlias(aliases, id, currentRoom.name);
-            }
-        }
-
-        return aliases;
-    }
-
-    _getStoredRoomIdAliases() {
-        if (typeof this.getStoreValue !== 'function') return {};
         try {
-            return this._parseRoomIdAliases(this.getStoreValue(ROOM_ID_ALIASES_STORE_KEY));
+            return this.getSetting(key);
         } catch (error) {
             this.error(
-                '[ROOMS] Failed to read persisted room id aliases: ' +
-                this._getSafeErrorDetails(error)
+                '[ROOMS] Failed to read cached ' +
+                key +
+                ': ' +
+                this._getSafeErrorDetails(error) +
+                '.'
             );
-            return {};
+            return undefined;
         }
     }
 
-    _resolveNumericRoomId(requestedId, currentRooms, cachedRooms, rawAliases) {
-        const numericId = Number(requestedId);
-        const rooms = this._normalizeRoomList(currentRooms);
-        const aliases = this._parseRoomIdAliases(rawAliases);
-        const aliasNames = aliases[String(numericId)] || [];
-
-        if (aliasNames.length > 1) {
-            return {
-                id: null,
-                reason: 'historical id is ambiguous (' + aliasNames.join(' / ') + ')'
-            };
-        }
-
-        if (aliasNames.length === 1) {
-            const name = aliasNames[0];
-            const canonicalName = this._roomNameKey(name);
-            const matches = rooms.filter(
-                (room) => this._roomNameKey(room.name) === canonicalName
-            );
-            if (matches.length === 1) {
-                const id = Number(matches[0].id);
-                return { id, name, remapped: id !== numericId };
-            }
-            return {
-                id: null,
-                reason: 'historical room name "' + name + '" is not unique in the current map'
-            };
-        }
-
-        const cachedRoom = this._normalizeRoomList(cachedRooms).find(
-            (room) => Number(room.id) === numericId
-        );
-        const exactCurrentRoom = rooms.find((room) => Number(room.id) === numericId);
-
-        if (cachedRoom && cachedRoom.name) {
-            const cachedName = this._roomNameKey(cachedRoom.name);
-            if (exactCurrentRoom && this._roomNameKey(exactCurrentRoom.name) === cachedName) {
-                return { id: numericId, name: cachedRoom.name, remapped: false };
-            }
-            const matches = rooms.filter((room) => this._roomNameKey(room.name) === cachedName);
-            if (matches.length === 1) {
-                const id = Number(matches[0].id);
-                return { id, name: cachedRoom.name, remapped: id !== numericId };
-            }
-            return {
-                id: null,
-                reason: 'cached room name "' + cachedRoom.name + '" is not unique in the current map'
-            };
-        }
-
-        if (exactCurrentRoom) {
-            return { id: numericId, name: exactCurrentRoom.name, remapped: false };
-        }
-
-        return { id: null, reason: 'id is not present in the current room map' };
+    _getCachedRoomsForCleaning() {
+        return this._parseRoomsSetting(this._getRoomSettingValue('rooms'));
     }
 
-    async _getRoomCleaningState() {
-        const cachedRooms = this._parseRoomsSetting(this.getSetting('rooms'));
-        const storedAliases = this._getStoredRoomIdAliases();
+    _getSemanticRoomName(room) {
+        if (!room || room._hasSemanticRoomName === false) return null;
+        return this._normalizeRoomName(room.name);
+    }
+
+    _normalizeRoomAlias(entry) {
+        if (!entry || typeof entry !== 'object' || !this._isValidRoomId(entry.id)) {
+            return null;
+        }
+
+        const name = this._normalizeRoomName(entry.name);
+        if (!name) return null;
+
+        return {
+            id: Number(entry.id),
+            name
+        };
+    }
+
+    _mergeRoomAliasEntries(existingEntries, additions) {
+        const aliases = [];
+
+        for (const entry of [...(existingEntries || []), ...(additions || [])]) {
+            const alias = this._normalizeRoomAlias(entry);
+            if (!alias) continue;
+
+            const aliasNameKey = this._roomNameKey(alias.name);
+            const previousIndex = aliases.findIndex(
+                (existing) =>
+                    existing.id === alias.id &&
+                    this._roomNameKey(existing.name) === aliasNameKey
+            );
+            if (previousIndex !== -1) aliases.splice(previousIndex, 1);
+            aliases.push(alias);
+        }
+
+        return aliases.slice(-MAX_ROOM_ALIAS_ENTRIES);
+    }
+
+    _roomAliasEntriesFromRooms(rooms) {
+        if (!Array.isArray(rooms)) return [];
+
+        return rooms
+            .map((room) => {
+                if (!room || !this._isValidRoomId(room.id)) return null;
+                const name = this._getSemanticRoomName(room);
+                return name ? { id: Number(room.id), name } : null;
+            })
+            .filter(Boolean);
+    }
+
+    _getRoomAliasHistory() {
+        if (this._roomAliasHistory) return this._roomAliasHistory;
+
+        let storedHistory;
+        try {
+            storedHistory =
+                typeof this.getStoreValue === 'function'
+                    ? this.getStoreValue(ROOM_ALIAS_STORE_KEY)
+                    : undefined;
+        } catch (error) {
+            this.error(
+                '[ROOMS] Failed to read room-name aliases: ' +
+                this._getSafeErrorDetails(error) +
+                '.'
+            );
+            this._roomAliasHistory = { version: ROOM_ALIAS_SCHEMA_VERSION, aliases: [] };
+            this._roomAliasHistoryPersisted = false;
+            return this._roomAliasHistory;
+        }
+
+        if (typeof storedHistory === 'string') {
+            try {
+                storedHistory = JSON.parse(storedHistory);
+            } catch (_) {
+                storedHistory = null;
+            }
+        }
+
+        const aliases =
+            storedHistory &&
+            storedHistory.version === ROOM_ALIAS_SCHEMA_VERSION &&
+            Array.isArray(storedHistory.aliases)
+                ? this._mergeRoomAliasEntries([], storedHistory.aliases)
+                : [];
+
+        this._roomAliasHistory = {
+            version: ROOM_ALIAS_SCHEMA_VERSION,
+            aliases
+        };
+        this._roomAliasHistoryPersisted = true;
+        return this._roomAliasHistory;
+    }
+
+    async _persistRoomAliases(...roomLists) {
+        const existingHistory = this._getRoomAliasHistory();
+        const additions = roomLists.flatMap((rooms) => this._roomAliasEntriesFromRooms(rooms));
+        const aliases = this._mergeRoomAliasEntries(existingHistory.aliases, additions);
+        const nextHistory = {
+            version: ROOM_ALIAS_SCHEMA_VERSION,
+            aliases
+        };
+        const contentChanged = JSON.stringify(existingHistory) !== JSON.stringify(nextHistory);
+        const historyIsDurable = this._roomAliasHistoryPersisted === true;
+
+        this._roomAliasHistory = nextHistory;
+
+        // A prior failed write leaves current aliases usable in memory, but they
+        // must be retried before rooms settings can advance past their fallback.
+        if (!contentChanged && historyIsDurable) {
+            return { history: nextHistory, persisted: true };
+        }
 
         try {
-            const refreshed = await this._refreshRoomsBeforeCleaning();
-            return {
-                cachedRooms,
-                rooms: refreshed.rooms.length ? refreshed.rooms : cachedRooms,
-                aliases: refreshed.aliases,
-                refreshed: true
-            };
+            await this.setStoreValue(ROOM_ALIAS_STORE_KEY, nextHistory);
+        } catch (error) {
+            this.error(
+                '[ROOMS] Failed to persist room-name aliases: ' +
+                this._getSafeErrorDetails(error) +
+                '.'
+            );
+            this._roomAliasHistoryPersisted = false;
+            return { history: nextHistory, persisted: false };
+        }
+
+        this._roomAliasHistoryPersisted = true;
+        return { history: nextHistory, persisted: true };
+    }
+
+    _getRoomAliasesForResolution(cachedRooms) {
+        const history = this._getRoomAliasHistory();
+        return this._mergeRoomAliasEntries(
+            history.aliases,
+            this._roomAliasEntriesFromRooms(cachedRooms)
+        );
+    }
+
+    async _resolveAdvancedRoomCleaningSelection(roomArgument) {
+        // Room IDs can change after editing the map in Xiaomi Home. Resolve the
+        // argument only after a live refresh; cached rooms are a read-failure
+        // fallback and never replace a successfully parsed live map.
+        const cachedRooms = this._getCachedRoomsForCleaning();
+        let rooms = cachedRooms;
+
+        try {
+            const refreshedRooms = await this._refreshRoomsBeforeCleaning();
+            if (refreshedRooms.length) rooms = refreshedRooms;
         } catch (error) {
             this.error(
                 '[ROOMS] Refresh before room clean failed: ' +
                 this._getSafeErrorDetails(error) +
                 '; using cached room list.'
             );
-            return {
-                cachedRooms,
-                rooms: cachedRooms,
-                aliases: storedAliases,
-                refreshed: false
-            };
         }
+
+        return {
+            rooms,
+            selectedIds: this._resolveRoomIdsForCleaning(roomArgument, rooms, cachedRooms)
+        };
+    }
+
+    _resolveRoomIdsForCleaning(roomArgument, currentRooms, cachedRooms) {
+        const rooms = (Array.isArray(currentRooms) ? currentRooms : []).filter(
+            (room) => room && this._isValidRoomId(room.id)
+        );
+        const aliases = this._getRoomAliasesForResolution(cachedRooms);
+        const aliasesById = new Map();
+
+        for (const alias of aliases) {
+            const nameKey = this._roomNameKey(alias.name);
+            if (!nameKey) continue;
+            if (!aliasesById.has(alias.id)) aliasesById.set(alias.id, new Set());
+            aliasesById.get(alias.id).add(nameKey);
+        }
+
+        const selectedIds = [];
+        if (roomArgument === 'all') {
+            selectedIds.push(...rooms.map((room) => Number(room.id)));
+        } else {
+            for (const rawToken of String(roomArgument || '').split(',')) {
+                const token = rawToken.trim();
+                if (!token) continue;
+
+                if (/^\d+$/.test(token)) {
+                    const requestedId = Number(token);
+                    if (!this._isValidRoomId(requestedId)) {
+                        this.log('[ROOMS] Requested numeric room id is not a positive integer.');
+                        continue;
+                    }
+
+                    const exactCurrentRooms = rooms.filter(
+                        (room) => Number(room.id) === requestedId
+                    );
+                    const historicalNames = aliasesById.get(requestedId) || new Set();
+
+                    if (exactCurrentRooms.length === 1) {
+                        const currentNameKey = this._roomNameKey(
+                            this._getSemanticRoomName(exactCurrentRooms[0])
+                        );
+                        const isReused = [...historicalNames].some(
+                            (historicalNameKey) =>
+                                !currentNameKey || historicalNameKey !== currentNameKey
+                        );
+
+                        if (!isReused) {
+                            selectedIds.push(Number(exactCurrentRooms[0].id));
+                            continue;
+                        }
+
+                        this.log(
+                            '[ROOMS] Requested numeric room id ' +
+                            requestedId +
+                            ' is ambiguous because the current room map reuses it.'
+                        );
+                        continue;
+                    }
+
+                    if (exactCurrentRooms.length > 1) {
+                        this.log(
+                            '[ROOMS] Requested numeric room id ' +
+                            requestedId +
+                            ' is ambiguous in the current room map.'
+                        );
+                        continue;
+                    }
+
+                    if (historicalNames.size !== 1) {
+                        this.log(
+                            '[ROOMS] Stale numeric room id ' +
+                            requestedId +
+                            ' has no unique historical room name.'
+                        );
+                        continue;
+                    }
+
+                    const [historicalNameKey] = historicalNames;
+                    const replacementRooms = rooms.filter(
+                        (room) =>
+                            this._roomNameKey(this._getSemanticRoomName(room)) ===
+                            historicalNameKey
+                    );
+
+                    if (replacementRooms.length === 1) {
+                        const replacementId = Number(replacementRooms[0].id);
+                        selectedIds.push(replacementId);
+                        this.log(
+                            '[ROOMS] Remapped stale numeric room id ' +
+                            requestedId +
+                            ' -> ' +
+                            replacementId +
+                            '.'
+                        );
+                    } else {
+                        this.log(
+                            '[ROOMS] Stale numeric room id ' +
+                            requestedId +
+                            ' does not uniquely match the current room map.'
+                        );
+                    }
+                    continue;
+                }
+
+                const requestedNameKey = this._roomNameKey(token);
+                const matchingRooms = requestedNameKey
+                    ? rooms.filter(
+                        (room) =>
+                            this._roomNameKey(this._getSemanticRoomName(room)) ===
+                            requestedNameKey
+                    )
+                    : [];
+
+                if (matchingRooms.length === 1) {
+                    selectedIds.push(Number(matchingRooms[0].id));
+                } else if (matchingRooms.length > 1) {
+                    this.log('[ROOMS] Requested room name is ambiguous in the current room map.');
+                } else {
+                    this.log('[ROOMS] Requested room name is not present in the current room map.');
+                }
+            }
+        }
+
+        return Array.from(new Set(selectedIds.filter((id) => this._isValidRoomId(id))));
     }
 
     _roomListSignature(rooms) {
@@ -1886,94 +1996,108 @@ class XiaomiVacuumMiotDeviceMax extends Device {
             .join('|');
     }
 
-
     async _refreshRoomsBeforeCleaning() {
         if (
             !this.deviceProperties ||
             !this.deviceProperties.supports ||
-            !this.deviceProperties.supports.rooms ||
-            !Array.isArray(this.deviceProperties.get_rooms) ||
-            !this.deviceProperties.get_rooms.length
+            !this.deviceProperties.supports.rooms
         ) {
-            throw new Error('No configured room property for this device.');
+            return [];
         }
 
-        const definition = this.deviceProperties.get_rooms;
-        const result = await this.callVacuumGetProperties(definition, { retries: 2 });
+        const candidates = [];
 
         if (
-            !Array.isArray(result) ||
-            !result[0] ||
-            result[0].value == null ||
-            result[0].value === ''
+            Array.isArray(this.deviceProperties.get_rooms) &&
+            this.deviceProperties.get_rooms.length
         ) {
-            throw new Error('No room data returned by the vacuum.');
+            candidates.push(this.deviceProperties.get_rooms);
         }
 
-        const rooms = this._parseRoomsPayload(result[0].value);
-        if (!rooms.length) throw new Error('No parsable room data returned by the vacuum.');
+        // Existing fallback locations retained from the 3.5.19 discovery code.
+        candidates.push(
+            [{ did: 'rooms', siid: 4, piid: 20 }],
+            [{ did: 'rooms', siid: 6, piid: 15 }],
+            [{ did: 'rooms', siid: 7, piid: 3 }]
+        );
 
-        const previousRooms = this._parseRoomsSetting(this.getSetting('rooms'));
-        const previousSignature = this._roomListSignature(previousRooms);
-        const newSignature = this._roomListSignature(rooms);
-        const previousAliases = this._getStoredRoomIdAliases();
-        const aliases = this._mergeRoomIdAliases(previousRooms, rooms, previousAliases);
+        let lastError = null;
 
-        const aliasesChanged = JSON.stringify(previousAliases) !== JSON.stringify(aliases);
-        let aliasesPersisted = !aliasesChanged;
-
-        if (aliasesChanged && typeof this.setStoreValue === 'function') {
+        for (const definition of candidates) {
+            let result;
             try {
-                await this.setStoreValue(ROOM_ID_ALIASES_STORE_KEY, aliases);
-                aliasesPersisted = true;
+                result = await this.callVacuumGetProperties(definition, { retries: 2 });
             } catch (error) {
-                this.error(
-                    '[ROOMS] Failed to persist room id aliases: ' +
-                    this._getSafeErrorDetails(error)
-                );
+                lastError = error;
+                continue;
             }
-        }
 
-        const settings = {
-            rooms: JSON.stringify(rooms),
-            rooms_display: rooms.map((room) => room.name || ('Room ' + room.id)).join(', ')
-        };
-        const settingsChanged =
-            this.getSetting('rooms') !== settings.rooms ||
-            this.getSetting('rooms_display') !== settings.rooms_display;
-
-        if (settingsChanged && aliasesChanged && !aliasesPersisted) {
-            // Do not overwrite the only persisted old-ID -> name association when
-            // alias storage is temporarily unavailable. The current action still
-            // uses the valid live room map, and a later run can retry persistence.
-            this.error(
-                '[ROOMS] Keeping previous room settings because room id aliases could not be persisted.'
-            );
-        } else if (settingsChanged) {
-            try {
-                await this.setSettings(settings);
-            } catch (error) {
-                this.error(
-                    '[ROOMS] Failed to persist refreshed room settings: ' +
-                    this._getSafeErrorDetails(error)
-                );
+            if (
+                !Array.isArray(result) ||
+                !result[0] ||
+                result[0].value == null ||
+                result[0].value === ''
+            ) {
+                continue;
             }
+
+            const rooms = this._parseRoomsPayload(result[0].value);
+            if (!rooms.length) continue;
+
+            const previousRoomsSetting = this._getRoomSettingValue('rooms');
+            const previousRooms = this._parseRoomsSetting(previousRoomsSetting);
+            const previousSignature = this._roomListSignature(previousRooms);
+            const newSignature = this._roomListSignature(rooms);
+
+            // Persist the old map before replacing its setting. Including the live
+            // map also keeps the next refresh recoverable if setting persistence
+            // fails after this action has already used the fresh data.
+            const aliasPersistence = await this._persistRoomAliases(previousRooms, rooms);
+
+            const settings = {
+                rooms: JSON.stringify(rooms),
+                rooms_display: rooms.map((room) => room.name || ('Room ' + room.id)).join(', ')
+            };
+            const previousRoomsDisplay = this._getRoomSettingValue('rooms_display');
+
+            const settingsChanged =
+                previousRoomsSetting !== settings.rooms ||
+                previousRoomsDisplay !== settings.rooms_display;
+
+            if (!aliasPersistence.persisted && settingsChanged) {
+                this.error(
+                    '[ROOMS] Skipped persisting refreshed room map because room-name aliases were not persisted; retaining cached room map.'
+                );
+            } else if (settingsChanged) {
+                try {
+                    await this.setSettings(settings);
+                } catch (error) {
+                    this.error(
+                        '[ROOMS] Failed to persist refreshed room map: ' +
+                        this._getSafeErrorDetails(error) +
+                        '.'
+                    );
+                }
+            }
+
+            this._roomsDiscovered = true;
+
+            if (previousSignature !== newSignature) {
+                this.log(
+                    '[ROOMS] Room map refreshed before cleaning: ' +
+                    (previousSignature || '(none)') +
+                    ' -> ' +
+                    newSignature
+                );
+            } else {
+                this.log('[ROOMS] Room map checked before cleaning: unchanged.');
+            }
+
+            return rooms;
         }
 
-        this._roomsDiscovered = true;
-
-        if (previousSignature !== newSignature) {
-            this.log(
-                '[ROOMS] Room map refreshed before cleaning: ' +
-                (previousSignature || '(none)') +
-                ' -> ' +
-                newSignature
-            );
-        } else {
-            this.log('[ROOMS] Room map checked before cleaning: unchanged.');
-        }
-
-        return { rooms, aliases };
+        if (lastError) throw lastError;
+        throw new Error('No parsable room data returned by the vacuum.');
     }
 
     getModelIdentifier() {

--- a/drivers/vacuum_xiaomi_vacuum_max/device.js
+++ b/drivers/vacuum_xiaomi_vacuum_max/device.js
@@ -167,6 +167,7 @@ const GET_PROPERTIES_CHUNK_SIZE = {
 };
 const DEFAULT_GET_PROPERTIES_CHUNK_SIZE = 5;
 const GET_PROPERTIES_CHUNK_DELAY_MS = 100;
+const ROOM_ID_ALIASES_STORE_KEY = 'roomIdAliases';
 
 /** Property sets */
 const properties = {
@@ -761,22 +762,12 @@ class XiaomiVacuumMiotDeviceMax extends Device {
                     return Promise.reject('Room cleaning is not supported by this device.');
                 }
                 // Room IDs can change after editing the map in Xiaomi Home.
-                // Always ask the vacuum for its current room map immediately before
-                // resolving the Flow room argument. Keep the cached list only as a
-                // fallback if that optional refresh fails.
-                const cachedRooms = args.device._parseRoomsSetting(args.device.getSetting('rooms'));
-                let list_room = cachedRooms;
-
-                try {
-                    const refreshedRooms = await args.device._refreshRoomsBeforeCleaning();
-                    if (refreshedRooms.length) list_room = refreshedRooms;
-                } catch (error) {
-                    args.device.error(
-                        '[ROOMS] Refresh before room clean failed: ' +
-                        args.device._getSafeErrorDetails(error) +
-                        '; using cached room list.'
-                    );
-                }
+                // Resolve against a live map when possible, while retaining persistent
+                // old-ID semantics for existing numeric Flow values.
+                const roomState = await args.device._getRoomCleaningState();
+                const cachedRooms = roomState.cachedRooms;
+                const list_room = roomState.rooms;
+                const roomAliases = roomState.aliases;
 
                 let selected_ids;
                 if (args.room === 'all') {
@@ -788,71 +779,33 @@ class XiaomiVacuumMiotDeviceMax extends Device {
                         if (!token) continue;
                         if (/^\d+$/.test(token)) {
                             const requestedId = Number(token);
-                            const oldRoom = cachedRooms.find(
-                                (room) => Number(room.id) === requestedId
+                            const resolution = args.device._resolveNumericRoomId(
+                                requestedId,
+                                list_room,
+                                cachedRooms,
+                                roomAliases
                             );
-                            const exactCurrentRoom = list_room.find(
-                                (room) => Number(room.id) === requestedId
-                            );
 
-                            // A numeric room ID may still exist after a Xiaomi map
-                            // edit but now belong to a different room. When we have
-                            // cached semantic information for that old ID, compare
-                            // the room name before trusting the numeric match.
-                            if (oldRoom && oldRoom.name) {
-                                const oldName = String(oldRoom.name).trim().toLowerCase();
-                                const exactCurrentName = exactCurrentRoom
-                                    ? String(exactCurrentRoom.name || '').trim().toLowerCase()
-                                    : '';
-
-                                if (exactCurrentRoom && exactCurrentName === oldName) {
-                                    selected_ids.push(Number(exactCurrentRoom.id));
-                                    continue;
+                            if (resolution.id != null) {
+                                selected_ids.push(resolution.id);
+                                if (resolution.remapped) {
+                                    args.device.log(
+                                        '[ROOMS] Remapped stale room id ' +
+                                        requestedId +
+                                        ' (' +
+                                        resolution.name +
+                                        ') -> ' +
+                                        resolution.id
+                                    );
                                 }
-
-                                const replacements = list_room.filter(
-                                    (room) =>
-                                        String(room.name || '').trim().toLowerCase() === oldName
-                                );
-
-                                if (replacements.length === 1) {
-                                    const replacementId = Number(replacements[0].id);
-                                    selected_ids.push(replacementId);
-
-                                    if (replacementId !== requestedId) {
-                                        args.device.log(
-                                            '[ROOMS] Remapped stale room id ' +
-                                            requestedId +
-                                            ' (' +
-                                            oldRoom.name +
-                                            ') -> ' +
-                                            replacementId
-                                        );
-                                    }
-                                    continue;
-                                }
-
-                                args.device.log(
-                                    '[ROOMS] Stale room id ' +
-                                    requestedId +
-                                    ' (' +
-                                    oldRoom.name +
-                                    ') could not be resolved uniquely in the current room map.'
-                                );
-                                continue;
-                            }
-
-                            // No cached meaning is known for this numeric ID, so a
-                            // currently existing ID can still be used as entered.
-                            if (exactCurrentRoom) {
-                                selected_ids.push(Number(exactCurrentRoom.id));
                                 continue;
                             }
 
                             args.device.log(
-                                '[ROOMS] Requested numeric room id ' +
+                                '[ROOMS] Numeric room id ' +
                                 requestedId +
-                                ' is not present in the current room map.'
+                                ' rejected: ' +
+                                resolution.reason
                             );
                             continue;
                         }
@@ -1759,6 +1712,169 @@ class XiaomiVacuumMiotDeviceMax extends Device {
         return this._normalizeRoomList(rooms);
     }
 
+
+    _roomNameKey(name) {
+        return String(name || '').trim().toLowerCase();
+    }
+
+    _parseRoomIdAliases(rawAliases) {
+        let value = rawAliases;
+        if (typeof value === 'string') {
+            try {
+                value = JSON.parse(value);
+            } catch (_) {
+                return {};
+            }
+        }
+        if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+
+        const aliases = {};
+        for (const [rawId, rawNames] of Object.entries(value)) {
+            const id = Number(rawId);
+            if (!Number.isFinite(id)) continue;
+            const names = Array.isArray(rawNames) ? rawNames : [rawNames];
+            for (const name of names) this._addRoomIdAlias(aliases, id, name);
+        }
+        return aliases;
+    }
+
+    _addRoomIdAlias(aliases, id, name) {
+        const numericId = Number(id);
+        const displayName = typeof name === 'string' ? name.trim() : '';
+        if (!Number.isFinite(numericId) || !displayName) return;
+
+        const key = String(numericId);
+        if (!Array.isArray(aliases[key])) aliases[key] = [];
+        const canonicalName = this._roomNameKey(displayName);
+        if (!aliases[key].some((existing) => this._roomNameKey(existing) === canonicalName)) {
+            aliases[key].push(displayName);
+        }
+    }
+
+    _mergeRoomIdAliases(previousRooms, currentRooms, rawAliases) {
+        const aliases = this._parseRoomIdAliases(rawAliases);
+        const previous = this._normalizeRoomList(previousRooms);
+        const current = this._normalizeRoomList(currentRooms);
+        const currentById = new Map(current.map((room) => [Number(room.id), room]));
+
+        for (const previousRoom of previous) {
+            const currentRoom = currentById.get(Number(previousRoom.id));
+            if (!currentRoom || this._roomNameKey(currentRoom.name) !== this._roomNameKey(previousRoom.name)) {
+                this._addRoomIdAlias(aliases, previousRoom.id, previousRoom.name);
+                if (currentRoom) this._addRoomIdAlias(aliases, previousRoom.id, currentRoom.name);
+            }
+        }
+
+        // If an ID with historical meaning is later reused, preserve both meanings.
+        // A numeric Flow using that ID is then intentionally rejected as ambiguous.
+        for (const [id, names] of Object.entries({ ...aliases })) {
+            const currentRoom = currentById.get(Number(id));
+            if (!currentRoom) continue;
+            if (names.some((name) => this._roomNameKey(name) !== this._roomNameKey(currentRoom.name))) {
+                this._addRoomIdAlias(aliases, id, currentRoom.name);
+            }
+        }
+
+        return aliases;
+    }
+
+    _getStoredRoomIdAliases() {
+        if (typeof this.getStoreValue !== 'function') return {};
+        try {
+            return this._parseRoomIdAliases(this.getStoreValue(ROOM_ID_ALIASES_STORE_KEY));
+        } catch (error) {
+            this.error(
+                '[ROOMS] Failed to read persisted room id aliases: ' +
+                this._getSafeErrorDetails(error)
+            );
+            return {};
+        }
+    }
+
+    _resolveNumericRoomId(requestedId, currentRooms, cachedRooms, rawAliases) {
+        const numericId = Number(requestedId);
+        const rooms = this._normalizeRoomList(currentRooms);
+        const aliases = this._parseRoomIdAliases(rawAliases);
+        const aliasNames = aliases[String(numericId)] || [];
+
+        if (aliasNames.length > 1) {
+            return {
+                id: null,
+                reason: 'historical id is ambiguous (' + aliasNames.join(' / ') + ')'
+            };
+        }
+
+        if (aliasNames.length === 1) {
+            const name = aliasNames[0];
+            const canonicalName = this._roomNameKey(name);
+            const matches = rooms.filter(
+                (room) => this._roomNameKey(room.name) === canonicalName
+            );
+            if (matches.length === 1) {
+                const id = Number(matches[0].id);
+                return { id, name, remapped: id !== numericId };
+            }
+            return {
+                id: null,
+                reason: 'historical room name "' + name + '" is not unique in the current map'
+            };
+        }
+
+        const cachedRoom = this._normalizeRoomList(cachedRooms).find(
+            (room) => Number(room.id) === numericId
+        );
+        const exactCurrentRoom = rooms.find((room) => Number(room.id) === numericId);
+
+        if (cachedRoom && cachedRoom.name) {
+            const cachedName = this._roomNameKey(cachedRoom.name);
+            if (exactCurrentRoom && this._roomNameKey(exactCurrentRoom.name) === cachedName) {
+                return { id: numericId, name: cachedRoom.name, remapped: false };
+            }
+            const matches = rooms.filter((room) => this._roomNameKey(room.name) === cachedName);
+            if (matches.length === 1) {
+                const id = Number(matches[0].id);
+                return { id, name: cachedRoom.name, remapped: id !== numericId };
+            }
+            return {
+                id: null,
+                reason: 'cached room name "' + cachedRoom.name + '" is not unique in the current map'
+            };
+        }
+
+        if (exactCurrentRoom) {
+            return { id: numericId, name: exactCurrentRoom.name, remapped: false };
+        }
+
+        return { id: null, reason: 'id is not present in the current room map' };
+    }
+
+    async _getRoomCleaningState() {
+        const cachedRooms = this._parseRoomsSetting(this.getSetting('rooms'));
+        const storedAliases = this._getStoredRoomIdAliases();
+
+        try {
+            const refreshed = await this._refreshRoomsBeforeCleaning();
+            return {
+                cachedRooms,
+                rooms: refreshed.rooms.length ? refreshed.rooms : cachedRooms,
+                aliases: refreshed.aliases,
+                refreshed: true
+            };
+        } catch (error) {
+            this.error(
+                '[ROOMS] Refresh before room clean failed: ' +
+                this._getSafeErrorDetails(error) +
+                '; using cached room list.'
+            );
+            return {
+                cachedRooms,
+                rooms: cachedRooms,
+                aliases: storedAliases,
+                refreshed: false
+            };
+        }
+    }
+
     _roomListSignature(rooms) {
         return this._normalizeRoomList(rooms)
             .map((room) => ({
@@ -1770,86 +1886,86 @@ class XiaomiVacuumMiotDeviceMax extends Device {
             .join('|');
     }
 
+
     async _refreshRoomsBeforeCleaning() {
         if (
             !this.deviceProperties ||
             !this.deviceProperties.supports ||
-            !this.deviceProperties.supports.rooms
+            !this.deviceProperties.supports.rooms ||
+            !Array.isArray(this.deviceProperties.get_rooms) ||
+            !this.deviceProperties.get_rooms.length
         ) {
-            return [];
+            throw new Error('No configured room property for this device.');
         }
 
-        const candidates = [];
+        const definition = this.deviceProperties.get_rooms;
+        const result = await this.callVacuumGetProperties(definition, { retries: 2 });
 
         if (
-            Array.isArray(this.deviceProperties.get_rooms) &&
-            this.deviceProperties.get_rooms.length
+            !Array.isArray(result) ||
+            !result[0] ||
+            result[0].value == null ||
+            result[0].value === ''
         ) {
-            candidates.push(this.deviceProperties.get_rooms);
+            throw new Error('No room data returned by the vacuum.');
         }
 
-        // Existing fallback locations retained from the 3.5.19 discovery code.
-        candidates.push(
-            [{ did: 'rooms', siid: 4, piid: 20 }],
-            [{ did: 'rooms', siid: 6, piid: 15 }],
-            [{ did: 'rooms', siid: 7, piid: 3 }]
-        );
+        const rooms = this._parseRoomsPayload(result[0].value);
+        if (!rooms.length) throw new Error('No parsable room data returned by the vacuum.');
 
-        let lastError = null;
+        const previousRooms = this._parseRoomsSetting(this.getSetting('rooms'));
+        const previousSignature = this._roomListSignature(previousRooms);
+        const newSignature = this._roomListSignature(rooms);
+        const previousAliases = this._getStoredRoomIdAliases();
+        const aliases = this._mergeRoomIdAliases(previousRooms, rooms, previousAliases);
 
-        for (const definition of candidates) {
+        if (
+            typeof this.setStoreValue === 'function' &&
+            JSON.stringify(previousAliases) !== JSON.stringify(aliases)
+        ) {
             try {
-                const result = await this.callVacuumGetProperties(definition, { retries: 2 });
-
-                if (
-                    !Array.isArray(result) ||
-                    !result[0] ||
-                    result[0].value == null ||
-                    result[0].value === ''
-                ) {
-                    continue;
-                }
-
-                const rooms = this._parseRoomsPayload(result[0].value);
-                if (!rooms.length) continue;
-
-                const previousRooms = this._parseRoomsSetting(this.getSetting('rooms'));
-                const previousSignature = this._roomListSignature(previousRooms);
-                const newSignature = this._roomListSignature(rooms);
-
-                const settings = {
-                    rooms: JSON.stringify(rooms),
-                    rooms_display: rooms.map((room) => room.name || ('Room ' + room.id)).join(', ')
-                };
-
-                if (
-                    this.getSetting('rooms') !== settings.rooms ||
-                    this.getSetting('rooms_display') !== settings.rooms_display
-                ) {
-                    await this.setSettings(settings);
-                }
-
-                this._roomsDiscovered = true;
-
-                if (previousSignature !== newSignature) {
-                    this.log(
-                        '[ROOMS] Room map refreshed before cleaning: ' +
-                        (previousSignature || '(none)') +
-                        ' -> ' +
-                        newSignature
-                    );
-                } else {
-                    this.log('[ROOMS] Room map checked before cleaning: unchanged.');
-                }
-
-                return rooms;
+                await this.setStoreValue(ROOM_ID_ALIASES_STORE_KEY, aliases);
             } catch (error) {
-                lastError = error;
+                this.error(
+                    '[ROOMS] Failed to persist room id aliases: ' +
+                    this._getSafeErrorDetails(error)
+                );
             }
         }
 
-        if (lastError) throw lastError;
-        throw new Error('No parsable room data returned by the vacuum.');
+        const settings = {
+            rooms: JSON.stringify(rooms),
+            rooms_display: rooms.map((room) => room.name || ('Room ' + room.id)).join(', ')
+        };
+
+        if (
+            this.getSetting('rooms') !== settings.rooms ||
+            this.getSetting('rooms_display') !== settings.rooms_display
+        ) {
+            try {
+                await this.setSettings(settings);
+            } catch (error) {
+                this.error(
+                    '[ROOMS] Failed to persist refreshed room settings: ' +
+                    this._getSafeErrorDetails(error)
+                );
+            }
+        }
+
+        this._roomsDiscovered = true;
+
+        if (previousSignature !== newSignature) {
+            this.log(
+                '[ROOMS] Room map refreshed before cleaning: ' +
+                (previousSignature || '(none)') +
+                ' -> ' +
+                newSignature
+            );
+        } else {
+            this.log('[ROOMS] Room map checked before cleaning: unchanged.');
+        }
+
+        return { rooms, aliases };
     }
 
     getModelIdentifier() {

--- a/drivers/vacuum_xiaomi_vacuum_max/device.js
+++ b/drivers/vacuum_xiaomi_vacuum_max/device.js
@@ -1919,12 +1919,13 @@ class XiaomiVacuumMiotDeviceMax extends Device {
         const previousAliases = this._getStoredRoomIdAliases();
         const aliases = this._mergeRoomIdAliases(previousRooms, rooms, previousAliases);
 
-        if (
-            typeof this.setStoreValue === 'function' &&
-            JSON.stringify(previousAliases) !== JSON.stringify(aliases)
-        ) {
+        const aliasesChanged = JSON.stringify(previousAliases) !== JSON.stringify(aliases);
+        let aliasesPersisted = !aliasesChanged;
+
+        if (aliasesChanged && typeof this.setStoreValue === 'function') {
             try {
                 await this.setStoreValue(ROOM_ID_ALIASES_STORE_KEY, aliases);
+                aliasesPersisted = true;
             } catch (error) {
                 this.error(
                     '[ROOMS] Failed to persist room id aliases: ' +
@@ -1937,11 +1938,18 @@ class XiaomiVacuumMiotDeviceMax extends Device {
             rooms: JSON.stringify(rooms),
             rooms_display: rooms.map((room) => room.name || ('Room ' + room.id)).join(', ')
         };
-
-        if (
+        const settingsChanged =
             this.getSetting('rooms') !== settings.rooms ||
-            this.getSetting('rooms_display') !== settings.rooms_display
-        ) {
+            this.getSetting('rooms_display') !== settings.rooms_display;
+
+        if (settingsChanged && aliasesChanged && !aliasesPersisted) {
+            // Do not overwrite the only persisted old-ID -> name association when
+            // alias storage is temporarily unavailable. The current action still
+            // uses the valid live room map, and a later run can retry persistence.
+            this.error(
+                '[ROOMS] Keeping previous room settings because room id aliases could not be persisted.'
+            );
+        } else if (settingsChanged) {
             try {
                 await this.setSettings(settings);
             } catch (error) {

--- a/test/vacuum-xiaomi-max-resilience.test.js
+++ b/test/vacuum-xiaomi-max-resilience.test.js
@@ -317,7 +317,7 @@ test('all property read/write call sites use retries two while action retries st
 
     assert.equal(propertyWriteLines.length, 6);
     assert.ok(propertyWriteLines.every((line) => line.includes('{ retries: 2 }')));
-    assert.equal(propertyReadLines.length, 4, 'main, room, candidate, and diagnostic reads must use the queue');
+    assert.equal(propertyReadLines.length, 5, 'main, room, candidate, diagnostic, and pre-clean refresh reads must use the queue');
     assert.ok(propertyReadLines.every((line) => line.includes('{ retries: 2 }')));
     assert.deepEqual(actionRetries, [3, 1, 1, 1]);
 });

--- a/test/vacuum-xiaomi-max-resilience.test.js
+++ b/test/vacuum-xiaomi-max-resilience.test.js
@@ -317,7 +317,7 @@ test('all property read/write call sites use retries two while action retries st
 
     assert.equal(propertyWriteLines.length, 6);
     assert.ok(propertyWriteLines.every((line) => line.includes('{ retries: 2 }')));
-    assert.equal(propertyReadLines.length, 5, 'main, room, candidate, diagnostic, and pre-clean refresh reads must use the queue');
+    assert.equal(propertyReadLines.length, 5, 'main, polling-room, cleaning-refresh, candidate, and diagnostic reads must use the queue');
     assert.ok(propertyReadLines.every((line) => line.includes('{ retries: 2 }')));
     assert.deepEqual(actionRetries, [3, 1, 1, 1]);
 });

--- a/test/vacuum-xiaomi-max-room-refresh.test.js
+++ b/test/vacuum-xiaomi-max-room-refresh.test.js
@@ -99,6 +99,35 @@ test('uses valid live room data when persisting refreshed settings fails', async
     assert.ok(fixture.errors.some(([message]) => String(message).includes('Failed to persist refreshed room settings')));
 });
 
+test('preserves the old semantic cache if alias persistence fails', async () => {
+    const fixture = createRoomDevice({
+        settingsRooms: [{ id: 48, name: 'Hall' }],
+        liveRooms: [{ id: 61, name: 'Hall' }],
+        storeError: new Error('store unavailable')
+    });
+    const state = await fixture.device._getRoomCleaningState();
+
+    assert.equal(state.refreshed, true);
+    assert.deepEqual(state.rooms, [{ id: 61, name: 'Hall' }]);
+    assert.equal(fixture.device._resolveNumericRoomId(48, state.rooms, state.cachedRooms, state.aliases).id, 61);
+    assert.equal(fixture.settings.rooms, JSON.stringify([{ id: 48, name: 'Hall' }]));
+    assert.ok(fixture.errors.some(([message]) => String(message).includes('Failed to persist room id aliases')));
+    assert.ok(fixture.errors.some(([message]) => String(message).includes('Keeping previous room settings')));
+
+    // Simulate an app restart with no alias store write having succeeded. The old
+    // settings still retain 48 -> Hall, so the live map can safely remap it again.
+    const restarted = createRoomDevice({
+        settingsRooms: [{ id: 48, name: 'Hall' }],
+        liveRooms: [{ id: 61, name: 'Hall' }],
+        storeError: new Error('store unavailable')
+    });
+    const restartedState = await restarted.device._getRoomCleaningState();
+    assert.equal(
+        restarted.device._resolveNumericRoomId(48, restartedState.rooms, restartedState.cachedRooms, restartedState.aliases).id,
+        61
+    );
+});
+
 test('rejects a numeric room id once the same id has ambiguous historical meaning', async () => {
     const fixture = createRoomDevice({
         settingsRooms: [

--- a/test/vacuum-xiaomi-max-room-refresh.test.js
+++ b/test/vacuum-xiaomi-max-room-refresh.test.js
@@ -1,0 +1,163 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+
+const originalModuleLoad = Module._load;
+Module._load = function loadWithHomeyStub(request, parent, isMain) {
+    if (request === 'homey') return { Device: class Device {} };
+    return originalModuleLoad.call(this, request, parent, isMain);
+};
+const VacuumDevice = require('../drivers/vacuum_xiaomi_vacuum_max/device.js');
+Module._load = originalModuleLoad;
+
+function createRoomDevice({
+    model = 'xiaomi.vacuum.d102gl',
+    settingsRooms = [],
+    storedAliases = {},
+    liveRooms = [],
+    readError = null,
+    settingsError = null,
+    storeError = null
+} = {}) {
+    const settings = {
+        rooms: JSON.stringify(settingsRooms),
+        rooms_display: settingsRooms.map((room) => room.name).join(', ')
+    };
+    let aliases = JSON.parse(JSON.stringify(storedAliases));
+    const calls = [];
+    const errors = [];
+    const logs = [];
+
+    const device = Object.create(VacuumDevice.prototype);
+    device.log = (...args) => logs.push(args);
+    device.error = (...args) => errors.push(args);
+    device._model = model;
+    device._applyModelProperties(model);
+    device.getSetting = (key) => settings[key];
+    device.getStoreValue = (key) => (key === 'roomIdAliases' ? aliases : undefined);
+    device.setStoreValue = async (key, value) => {
+        if (storeError) throw storeError;
+        if (key === 'roomIdAliases') aliases = JSON.parse(JSON.stringify(value));
+    };
+    device.setSettings = async (update) => {
+        if (settingsError) throw settingsError;
+        Object.assign(settings, update);
+    };
+    device.callVacuumGetProperties = async (definition, options) => {
+        calls.push({ definition, options });
+        if (readError) throw readError;
+        return [{
+            ...definition[0],
+            value: JSON.stringify({ rooms: liveRooms })
+        }];
+    };
+
+    return {
+        aliases: () => JSON.parse(JSON.stringify(aliases)),
+        calls,
+        device,
+        errors,
+        logs,
+        settings
+    };
+}
+
+test('persists stale numeric room semantics across repeated runs and app restarts', async () => {
+    const first = createRoomDevice({
+        settingsRooms: [{ id: 48, name: 'Hall' }],
+        liveRooms: [{ id: 61, name: 'Hall' }]
+    });
+    const firstState = await first.device._getRoomCleaningState();
+    assert.equal(first.device._resolveNumericRoomId(48, firstState.rooms, firstState.cachedRooms, firstState.aliases).id, 61);
+    assert.deepEqual(first.aliases(), { 48: ['Hall'] });
+
+    const second = createRoomDevice({
+        settingsRooms: [{ id: 61, name: 'Hall' }],
+        storedAliases: first.aliases(),
+        liveRooms: [{ id: 61, name: 'Hall' }]
+    });
+    const secondState = await second.device._getRoomCleaningState();
+    const secondResolution = second.device._resolveNumericRoomId(48, secondState.rooms, secondState.cachedRooms, secondState.aliases);
+    assert.equal(secondResolution.id, 61);
+    assert.equal(secondResolution.remapped, true);
+    assert.deepEqual(second.aliases(), { 48: ['Hall'] });
+});
+
+test('uses valid live room data when persisting refreshed settings fails', async () => {
+    const fixture = createRoomDevice({
+        settingsRooms: [{ id: 48, name: 'Hall' }],
+        liveRooms: [{ id: 61, name: 'Hall' }],
+        settingsError: new Error('settings unavailable')
+    });
+    const state = await fixture.device._getRoomCleaningState();
+
+    assert.equal(state.refreshed, true);
+    assert.deepEqual(state.rooms, [{ id: 61, name: 'Hall' }]);
+    assert.equal(fixture.device._resolveNumericRoomId(48, state.rooms, state.cachedRooms, state.aliases).id, 61);
+    assert.ok(fixture.errors.some(([message]) => String(message).includes('Failed to persist refreshed room settings')));
+});
+
+test('rejects a numeric room id once the same id has ambiguous historical meaning', async () => {
+    const fixture = createRoomDevice({
+        settingsRooms: [
+            { id: 48, name: 'Kitchen' },
+            { id: 61, name: 'Hall' }
+        ],
+        storedAliases: { 48: ['Hall'] },
+        liveRooms: [
+            { id: 48, name: 'Kitchen' },
+            { id: 61, name: 'Hall' }
+        ]
+    });
+    const state = await fixture.device._getRoomCleaningState();
+    const resolution = fixture.device._resolveNumericRoomId(48, state.rooms, state.cachedRooms, state.aliases);
+
+    assert.equal(resolution.id, null);
+    assert.match(resolution.reason, /ambiguous/);
+    assert.deepEqual(fixture.aliases(), { 48: ['Hall', 'Kitchen'] });
+});
+
+test('falls back to cached rooms and persisted aliases when live refresh fails', async () => {
+    const fixture = createRoomDevice({
+        settingsRooms: [{ id: 61, name: 'Hall' }],
+        storedAliases: { 48: ['Hall'] },
+        readError: new Error('room read timeout')
+    });
+    const state = await fixture.device._getRoomCleaningState();
+
+    assert.equal(state.refreshed, false);
+    assert.deepEqual(state.rooms, [{ id: 61, name: 'Hall' }]);
+    assert.equal(fixture.device._resolveNumericRoomId(48, state.rooms, state.cachedRooms, state.aliases).id, 61);
+    assert.ok(fixture.errors.some(([message]) => String(message).includes('room read timeout')));
+});
+
+test('pre-clean refresh routes through each model configured get_rooms descriptor', async () => {
+    const cases = [
+        ['xiaomi.vacuum.d109gl', 2, 16],
+        ['xiaomi.vacuum.d102gl', 2, 16],
+        ['xiaomi.vacuum.d101', 2, 16],
+        ['xiaomi.vacuum.d101gl', 2, 16],
+        ['xiaomi.vacuum.ov51gl', 2, 16],
+        ['xiaomi.vacuum.ov71gl', 2, 16],
+        ['xiaomi.vacuum.c102gl', 2, 16],
+        ['xiaomi.vacuum.b108gl', 2, 13]
+    ];
+
+    for (const [model, siid, piid] of cases) {
+        const fixture = createRoomDevice({
+            model,
+            settingsRooms: [{ id: 1, name: 'Room' }],
+            liveRooms: [{ id: 1, name: 'Room' }]
+        });
+        await fixture.device._refreshRoomsBeforeCleaning();
+        assert.equal(fixture.calls.length, 1, model);
+        assert.deepEqual(fixture.calls[0].definition, [{ did: 'rooms', siid, piid }], model);
+        assert.equal(fixture.calls[0].options.retries, 2, model);
+    }
+
+    const excluded = createRoomDevice({ model: 'xiaomi.vacuum.c108' });
+    await assert.rejects(excluded.device._refreshRoomsBeforeCleaning(), /No configured room property/);
+    assert.equal(excluded.calls.length, 0);
+});

--- a/test/vacuum-xiaomi-max-room-refresh.test.js
+++ b/test/vacuum-xiaomi-max-room-refresh.test.js
@@ -6,187 +6,354 @@ const Module = require('node:module');
 
 const originalModuleLoad = Module._load;
 Module._load = function loadWithHomeyStub(request, parent, isMain) {
-    if (request === 'homey') return { Device: class Device {} };
+    if (request === 'homey') {
+        return { Device: class Device {} };
+    }
+    if (request === '../wifi_device.js' && /vacuum_xiaomi_vacuum_max[\\/]device\.js$/.test(parent.filename)) {
+        return class Device {};
+    }
     return originalModuleLoad.call(this, request, parent, isMain);
 };
+
 const VacuumDevice = require('../drivers/vacuum_xiaomi_vacuum_max/device.js');
 Module._load = originalModuleLoad;
 
+function clone(value) {
+    return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+function roomPayload(rooms) {
+    return [{ value: JSON.stringify({ rooms }) }];
+}
+
 function createRoomDevice({
     model = 'xiaomi.vacuum.d102gl',
-    settingsRooms = [],
-    storedAliases = {},
-    liveRooms = [],
-    readError = null,
-    settingsError = null,
-    storeError = null
+    responses = [],
+    settings = {},
+    store = {},
+    setSettingsFailure = null,
+    setStoreFailure = null
 } = {}) {
-    const settings = {
-        rooms: JSON.stringify(settingsRooms),
-        rooms_display: settingsRooms.map((room) => room.name).join(', ')
-    };
-    let aliases = JSON.parse(JSON.stringify(storedAliases));
     const calls = [];
     const errors = [];
     const logs = [];
-
+    const settingsWrites = [];
+    const storeWrites = [];
     const device = Object.create(VacuumDevice.prototype);
-    device.log = (...args) => logs.push(args);
-    device.error = (...args) => errors.push(args);
+
     device._model = model;
-    device._applyModelProperties(model);
     device.getSetting = (key) => settings[key];
-    device.getStoreValue = (key) => (key === 'roomIdAliases' ? aliases : undefined);
+    device.setSettings = async (updates) => {
+        settingsWrites.push(clone(updates));
+        if (setSettingsFailure) throw setSettingsFailure;
+        Object.assign(settings, clone(updates));
+    };
+    device.getStoreValue = (key) => clone(store[key]);
     device.setStoreValue = async (key, value) => {
-        if (storeError) throw storeError;
-        if (key === 'roomIdAliases') aliases = JSON.parse(JSON.stringify(value));
+        storeWrites.push({ key, value: clone(value) });
+        if (setStoreFailure) throw setStoreFailure;
+        store[key] = clone(value);
     };
-    device.setSettings = async (update) => {
-        if (settingsError) throw settingsError;
-        Object.assign(settings, update);
+    device.callVacuumGetProperties = async (definitions, options) => {
+        calls.push({ definitions: clone(definitions), options: clone(options) });
+        const response = responses.shift();
+        if (response instanceof Error) throw response;
+        return clone(response);
     };
-    device.callVacuumGetProperties = async (definition, options) => {
-        calls.push({ definition, options });
-        if (readError) throw readError;
-        return [{
-            ...definition[0],
-            value: JSON.stringify({ rooms: liveRooms })
-        }];
-    };
+    device.error = (...args) => errors.push(args);
+    device.log = (...args) => logs.push(args);
+    device._applyModelProperties(model);
 
     return {
-        aliases: () => JSON.parse(JSON.stringify(aliases)),
         calls,
         device,
         errors,
         logs,
-        settings
+        settings,
+        settingsWrites,
+        store,
+        storeWrites
     };
 }
 
-test('persists stale numeric room semantics across repeated runs and app restarts', async () => {
+test('refreshes each room-capable model through its configured room property first', async () => {
+    const cases = [
+        { model: 'xiaomi.vacuum.d102gl', expected: [{ did: 'rooms', siid: 2, piid: 16 }] },
+        { model: 'xiaomi.vacuum.d109gl', expected: [{ did: 'rooms', siid: 2, piid: 16 }] },
+        { model: 'xiaomi.vacuum.b108gl', expected: [{ did: 'rooms', siid: 2, piid: 13 }] }
+    ];
+
+    for (const { model, expected } of cases) {
+        const subject = createRoomDevice({
+            model,
+            responses: [roomPayload([{ id: 11, name: 'Kitchen' }])]
+        });
+
+        const rooms = await subject.device._refreshRoomsBeforeCleaning();
+
+        assert.deepEqual(rooms, [{ id: 11, name: 'Kitchen' }], model);
+        assert.equal(subject.calls.length, 1, model);
+        assert.deepEqual(subject.calls[0].definitions, expected, model);
+    }
+
+    const unsupported = createRoomDevice({ model: 'xiaomi.vacuum.c108' });
+    assert.deepEqual(await unsupported.device._refreshRoomsBeforeCleaning(), []);
+    assert.equal(unsupported.calls.length, 0);
+});
+
+test('keeps stale numeric room IDs resolvable across refreshes and a device restart', async () => {
+    const settings = {
+        rooms: JSON.stringify([{ id: 1, name: 'Kitchen' }]),
+        rooms_display: 'Kitchen'
+    };
+    const store = {};
     const first = createRoomDevice({
-        settingsRooms: [{ id: 48, name: 'Hall' }],
-        liveRooms: [{ id: 61, name: 'Hall' }]
+        responses: [roomPayload([{ id: 2, name: 'Kitchen' }])],
+        settings,
+        store
     });
-    const firstState = await first.device._getRoomCleaningState();
-    assert.equal(first.device._resolveNumericRoomId(48, firstState.rooms, firstState.cachedRooms, firstState.aliases).id, 61);
-    assert.deepEqual(first.aliases(), { 48: ['Hall'] });
+    const cachedBeforeFirstRefresh = first.device._getCachedRoomsForCleaning();
+    const roomsAfterFirstRefresh = await first.device._refreshRoomsBeforeCleaning();
 
-    const second = createRoomDevice({
-        settingsRooms: [{ id: 61, name: 'Hall' }],
-        storedAliases: first.aliases(),
-        liveRooms: [{ id: 61, name: 'Hall' }]
+    assert.deepEqual(
+        first.device._resolveRoomIdsForCleaning('1', roomsAfterFirstRefresh, cachedBeforeFirstRefresh),
+        [2]
+    );
+    assert.deepEqual(store.room_id_name_aliases, {
+        version: 1,
+        aliases: [
+            { id: 1, name: 'Kitchen' },
+            { id: 2, name: 'Kitchen' }
+        ]
     });
-    const secondState = await second.device._getRoomCleaningState();
-    const secondResolution = second.device._resolveNumericRoomId(48, secondState.rooms, secondState.cachedRooms, secondState.aliases);
-    assert.equal(secondResolution.id, 61);
-    assert.equal(secondResolution.remapped, true);
-    assert.deepEqual(second.aliases(), { 48: ['Hall'] });
-});
 
-test('uses valid live room data when persisting refreshed settings fails', async () => {
-    const fixture = createRoomDevice({
-        settingsRooms: [{ id: 48, name: 'Hall' }],
-        liveRooms: [{ id: 61, name: 'Hall' }],
-        settingsError: new Error('settings unavailable')
-    });
-    const state = await fixture.device._getRoomCleaningState();
+    first.device.callVacuumGetProperties = async () => roomPayload([{ id: 3, name: 'Kitchen' }]);
+    const cachedBeforeSecondRefresh = first.device._getCachedRoomsForCleaning();
+    const roomsAfterSecondRefresh = await first.device._refreshRoomsBeforeCleaning();
 
-    assert.equal(state.refreshed, true);
-    assert.deepEqual(state.rooms, [{ id: 61, name: 'Hall' }]);
-    assert.equal(fixture.device._resolveNumericRoomId(48, state.rooms, state.cachedRooms, state.aliases).id, 61);
-    assert.ok(fixture.errors.some(([message]) => String(message).includes('Failed to persist refreshed room settings')));
-});
+    assert.deepEqual(
+        first.device._resolveRoomIdsForCleaning('1,2', roomsAfterSecondRefresh, cachedBeforeSecondRefresh),
+        [3]
+    );
 
-test('preserves the old semantic cache if alias persistence fails', async () => {
-    const fixture = createRoomDevice({
-        settingsRooms: [{ id: 48, name: 'Hall' }],
-        liveRooms: [{ id: 61, name: 'Hall' }],
-        storeError: new Error('store unavailable')
-    });
-    const state = await fixture.device._getRoomCleaningState();
-
-    assert.equal(state.refreshed, true);
-    assert.deepEqual(state.rooms, [{ id: 61, name: 'Hall' }]);
-    assert.equal(fixture.device._resolveNumericRoomId(48, state.rooms, state.cachedRooms, state.aliases).id, 61);
-    assert.equal(fixture.settings.rooms, JSON.stringify([{ id: 48, name: 'Hall' }]));
-    assert.ok(fixture.errors.some(([message]) => String(message).includes('Failed to persist room id aliases')));
-    assert.ok(fixture.errors.some(([message]) => String(message).includes('Keeping previous room settings')));
-
-    // Simulate an app restart with no alias store write having succeeded. The old
-    // settings still retain 48 -> Hall, so the live map can safely remap it again.
     const restarted = createRoomDevice({
-        settingsRooms: [{ id: 48, name: 'Hall' }],
-        liveRooms: [{ id: 61, name: 'Hall' }],
-        storeError: new Error('store unavailable')
+        responses: [roomPayload([{ id: 4, name: 'Kitchen' }])],
+        settings,
+        store
     });
-    const restartedState = await restarted.device._getRoomCleaningState();
-    assert.equal(
-        restarted.device._resolveNumericRoomId(48, restartedState.rooms, restartedState.cachedRooms, restartedState.aliases).id,
-        61
+    const cachedBeforeRestartRefresh = restarted.device._getCachedRoomsForCleaning();
+    const roomsAfterRestartRefresh = await restarted.device._refreshRoomsBeforeCleaning();
+
+    assert.deepEqual(
+        restarted.device._resolveRoomIdsForCleaning(
+            '1,2,3',
+            roomsAfterRestartRefresh,
+            cachedBeforeRestartRefresh
+        ),
+        [4]
+    );
+    assert.deepEqual(store.room_id_name_aliases.aliases, [
+        { id: 1, name: 'Kitchen' },
+        { id: 2, name: 'Kitchen' },
+        { id: 3, name: 'Kitchen' },
+        { id: 4, name: 'Kitchen' }
+    ]);
+});
+
+test('rejects reused IDs and duplicate names while retaining explicit unique names', () => {
+    const subject = createRoomDevice({
+        store: {
+            room_id_name_aliases: {
+                version: 1,
+                aliases: [{ id: 7, name: 'Kitchen' }]
+            }
+        }
+    });
+    const reusedCurrentRooms = subject.device._parseRoomsPayload(
+        JSON.stringify({
+            rooms: [
+                { id: 7, name: 'Office' },
+                { id: 8, name: 'Kitchen' }
+            ]
+        })
+    );
+
+    assert.deepEqual(
+        subject.device._resolveRoomIdsForCleaning('7', reusedCurrentRooms, []),
+        []
+    );
+    assert.deepEqual(
+        subject.device._resolveRoomIdsForCleaning('Kitchen,8,Kitchen', reusedCurrentRooms, []),
+        [8]
+    );
+
+    const duplicateNameRooms = subject.device._parseRoomsPayload(
+        JSON.stringify({
+            rooms: [
+                { id: 9, name: 'Kitchen' },
+                { id: 10, name: 'Kitchen' }
+            ]
+        })
+    );
+    assert.deepEqual(
+        subject.device._resolveRoomIdsForCleaning('7,Kitchen', duplicateNameRooms, []),
+        []
     );
 });
 
-test('rejects a numeric room id once the same id has ambiguous historical meaning', async () => {
-    const fixture = createRoomDevice({
-        settingsRooms: [
-            { id: 48, name: 'Kitchen' },
-            { id: 61, name: 'Hall' }
+test('retains cached rooms after alias persistence fails while the current action uses fresh rooms', async () => {
+    const secretStoreError = new Error('token=not-for-logs');
+    const settings = {
+        rooms: JSON.stringify([{ id: 21, name: 'Kitchen' }]),
+        rooms_display: 'Kitchen'
+    };
+    const store = {};
+    const subject = createRoomDevice({
+        responses: [
+            roomPayload([{ id: 22, name: 'Kitchen' }]),
+            roomPayload([{ id: 22, name: 'Kitchen' }])
         ],
-        storedAliases: { 48: ['Hall'] },
-        liveRooms: [
-            { id: 48, name: 'Kitchen' },
-            { id: 61, name: 'Hall' }
+        settings,
+        store,
+        setStoreFailure: secretStoreError
+    });
+    const firstSelection = await subject.device._resolveAdvancedRoomCleaningSelection('21');
+    const secondSelection = await subject.device._resolveAdvancedRoomCleaningSelection('21');
+
+    assert.deepEqual(firstSelection.rooms, [{ id: 22, name: 'Kitchen' }]);
+    assert.deepEqual(firstSelection.selectedIds, [22]);
+    assert.deepEqual(secondSelection.rooms, [{ id: 22, name: 'Kitchen' }]);
+    assert.deepEqual(secondSelection.selectedIds, [22]);
+    assert.equal(subject.calls.length, 2);
+    assert.equal(settings.rooms, JSON.stringify([{ id: 21, name: 'Kitchen' }]));
+    assert.equal(settings.rooms_display, 'Kitchen');
+    assert.equal(subject.settingsWrites.length, 0);
+    assert.equal(subject.storeWrites.length, 2);
+    assert.equal(store.room_id_name_aliases, undefined);
+    const errorText = subject.errors.flat().join(' ');
+    assert.match(errorText, /Failed to persist room-name aliases/);
+    assert.match(errorText, /Skipped persisting refreshed room map/);
+    assert.doesNotMatch(errorText, /not-for-logs/);
+
+    const restarted = createRoomDevice({
+        responses: [roomPayload([{ id: 22, name: 'Kitchen' }])],
+        settings,
+        store
+    });
+    const restartedSelection = await restarted.device._resolveAdvancedRoomCleaningSelection('21');
+
+    assert.deepEqual(restartedSelection.rooms, [{ id: 22, name: 'Kitchen' }]);
+    assert.deepEqual(restartedSelection.selectedIds, [22]);
+    assert.deepEqual(store.room_id_name_aliases, {
+        version: 1,
+        aliases: [
+            { id: 21, name: 'Kitchen' },
+            { id: 22, name: 'Kitchen' }
         ]
     });
-    const state = await fixture.device._getRoomCleaningState();
-    const resolution = fixture.device._resolveNumericRoomId(48, state.rooms, state.cachedRooms, state.aliases);
-
-    assert.equal(resolution.id, null);
-    assert.match(resolution.reason, /ambiguous/);
-    assert.deepEqual(fixture.aliases(), { 48: ['Hall', 'Kitchen'] });
 });
 
-test('falls back to cached rooms and persisted aliases when live refresh fails', async () => {
-    const fixture = createRoomDevice({
-        settingsRooms: [{ id: 61, name: 'Hall' }],
-        storedAliases: { 48: ['Hall'] },
-        readError: new Error('room read timeout')
+test('uses fresh rooms when settings persistence fails after aliases persist', async () => {
+    const secretSettingsError = new Error('cookie=not-for-logs');
+    const settings = {
+        rooms: JSON.stringify([{ id: 21, name: 'Kitchen' }]),
+        rooms_display: 'Kitchen'
+    };
+    const store = {};
+    const subject = createRoomDevice({
+        responses: [roomPayload([{ id: 22, name: 'Kitchen' }])],
+        settings,
+        store,
+        setSettingsFailure: secretSettingsError
     });
-    const state = await fixture.device._getRoomCleaningState();
+    const selection = await subject.device._resolveAdvancedRoomCleaningSelection('21');
 
-    assert.equal(state.refreshed, false);
-    assert.deepEqual(state.rooms, [{ id: 61, name: 'Hall' }]);
-    assert.equal(fixture.device._resolveNumericRoomId(48, state.rooms, state.cachedRooms, state.aliases).id, 61);
-    assert.ok(fixture.errors.some(([message]) => String(message).includes('room read timeout')));
+    assert.deepEqual(selection.rooms, [{ id: 22, name: 'Kitchen' }]);
+    assert.equal(subject.calls.length, 1);
+    assert.deepEqual(selection.selectedIds, [22]);
+    assert.equal(subject.settingsWrites.length, 1);
+    assert.deepEqual(store.room_id_name_aliases, {
+        version: 1,
+        aliases: [
+            { id: 21, name: 'Kitchen' },
+            { id: 22, name: 'Kitchen' }
+        ]
+    });
+    const errorText = subject.errors.flat().join(' ');
+    assert.match(errorText, /Failed to persist refreshed room map/);
+    assert.doesNotMatch(errorText, /not-for-logs/);
 });
 
-test('pre-clean refresh routes through each model configured get_rooms descriptor', async () => {
-    const cases = [
-        ['xiaomi.vacuum.d109gl', 2, 16],
-        ['xiaomi.vacuum.d102gl', 2, 16],
-        ['xiaomi.vacuum.d101', 2, 16],
-        ['xiaomi.vacuum.d101gl', 2, 16],
-        ['xiaomi.vacuum.ov51gl', 2, 16],
-        ['xiaomi.vacuum.ov71gl', 2, 16],
-        ['xiaomi.vacuum.c102gl', 2, 16],
-        ['xiaomi.vacuum.b108gl', 2, 13]
-    ];
+test('falls back through known room properties and never resolves unknown numeric IDs', async () => {
+    const subject = createRoomDevice({
+        responses: [
+            [{ value: '[]' }],
+            roomPayload([{ id: 31, name: 'Hall' }])
+        ]
+    });
 
-    for (const [model, siid, piid] of cases) {
-        const fixture = createRoomDevice({
-            model,
-            settingsRooms: [{ id: 1, name: 'Room' }],
-            liveRooms: [{ id: 1, name: 'Room' }]
-        });
-        await fixture.device._refreshRoomsBeforeCleaning();
-        assert.equal(fixture.calls.length, 1, model);
-        assert.deepEqual(fixture.calls[0].definition, [{ did: 'rooms', siid, piid }], model);
-        assert.equal(fixture.calls[0].options.retries, 2, model);
-    }
+    const rooms = await subject.device._refreshRoomsBeforeCleaning();
 
-    const excluded = createRoomDevice({ model: 'xiaomi.vacuum.c108' });
-    await assert.rejects(excluded.device._refreshRoomsBeforeCleaning(), /No configured room property/);
-    assert.equal(excluded.calls.length, 0);
+    assert.deepEqual(rooms, [{ id: 31, name: 'Hall' }]);
+    assert.equal(subject.calls.length, 2);
+    assert.deepEqual(subject.calls[0].definitions, [{ did: 'rooms', siid: 2, piid: 16 }]);
+    assert.deepEqual(subject.calls[1].definitions, [{ did: 'rooms', siid: 4, piid: 20 }]);
+
+    const cachedRooms = subject.device._parseRoomsSetting(
+        JSON.stringify([{ id: 31, name: 'Hall' }])
+    );
+    assert.deepEqual(subject.device._resolveRoomIdsForCleaning('31,999,0', cachedRooms, cachedRooms), [31]);
+});
+
+test('selection falls back to cached rooms when every live room read fails or cannot parse', async () => {
+    const subject = createRoomDevice({
+        settings: {
+            rooms: JSON.stringify([{ id: 41, name: 'Hall' }]),
+            rooms_display: 'Hall'
+        },
+        responses: [
+            new Error('network read failed'),
+            [{ value: 'not-json' }],
+            [{ value: '[]' }],
+            new Error('token=not-for-logs')
+        ]
+    });
+
+    const selection = await subject.device._resolveAdvancedRoomCleaningSelection('41,999');
+
+    assert.deepEqual(selection.rooms, [{ id: 41, name: 'Hall' }]);
+    assert.deepEqual(selection.selectedIds, [41]);
+    assert.equal(subject.calls.length, 4);
+    assert.deepEqual(subject.calls.map((call) => call.definitions), [
+        [{ did: 'rooms', siid: 2, piid: 16 }],
+        [{ did: 'rooms', siid: 4, piid: 20 }],
+        [{ did: 'rooms', siid: 6, piid: 15 }],
+        [{ did: 'rooms', siid: 7, piid: 3 }]
+    ]);
+    const errorText = subject.errors.flat().join(' ');
+    assert.match(errorText, /Refresh before room clean failed/);
+    assert.doesNotMatch(errorText, /not-for-logs/);
+});
+
+test('bounds semantic aliases and excludes malformed room data', async () => {
+    const subject = createRoomDevice();
+    const rooms = Array.from({ length: 65 }, (_, index) => ({
+        id: index + 1,
+        name: 'Room-' + (index + 1)
+    }));
+
+    await subject.device._persistRoomAliases(rooms, [
+        { id: 66 },
+        { id: 0, name: 'Invalid' },
+        { id: 67.5, name: 'Invalid' }
+    ]);
+
+    assert.equal(subject.store.room_id_name_aliases.version, 1);
+    assert.equal(subject.store.room_id_name_aliases.aliases.length, 64);
+    assert.deepEqual(subject.store.room_id_name_aliases.aliases[0], { id: 2, name: 'Room-2' });
+    assert.deepEqual(subject.store.room_id_name_aliases.aliases.at(-1), { id: 65, name: 'Room-65' });
+    assert.equal(
+        subject.store.room_id_name_aliases.aliases.some((alias) => alias.id === 66),
+        false
+    );
 });


### PR DESCRIPTION
## Summary

Room IDs can change after editing rooms in Xiaomi Home, while Homey can retain the previously discovered room list. Existing Advanced Room Cleaning Flows that contain numeric room IDs can then target stale IDs.

This change:
- refreshes the room map through the model's configured `get_rooms` descriptor immediately before Advanced Room Cleaning, with the existing fallback room properties retained
- persists a bounded per-device `room_id_name_aliases` history so old numeric Flow values retain their room-name meaning across repeated runs and app restarts
- remaps a stale numeric ID only when its historical room name has one unique match in the current map
- rejects reused numeric IDs and duplicate room-name matches instead of risking the wrong room
- uses valid live room data for the current action even if room settings or alias persistence fails
- keeps the previous semantic room cache when alias persistence fails and retries durable storage on later runs before advancing the cached settings
- falls back to cached rooms if every live room read fails
- updates `rooms` / `rooms_display` when persistence is safe and the map changed

The extra room read happens only when Advanced Room Cleaning starts, not during normal polling.

## Compatibility

Static routing and regression coverage verifies:
- d109gl / d102gl: 2/16
- d101 / d101gl / ov51gl / ov71gl: 2/16
- c102gl: 2/16
- b108gl: 2/13
- c108: excluded

Only `xiaomi.vacuum.d102gl` has real-device confirmation; the other room-capable models are statically supported and runtime-unverified.

## Testing

Real-device confirmation on Xiaomi Robot Vacuum X20 Pro (`xiaomi.vacuum.d102gl`): after editing the Xiaomi map, Hall changed to room ID `61`; an existing Homey room-cleaning Flow using the old mapping was remapped and the robot cleaned the correct Hall. A second map edit was also exercised with the existing Flow left unchanged.

The maintainer hardening for repeated invocation/restart persistence, ambiguous IDs, and write-failure handling is covered by focused virtual regression tests and has not yet been physically retested on the X20 Pro.

Maintainer validation:
- `node --check` on modified JavaScript and test files
- focused room-refresh/resilience tests: 14/14 passed
- full `node --test`: 90/90 passed
- clean `npm ci`: 111 packages audited, 0 vulnerabilities
- `npm audit --omit=dev`: 0 vulnerabilities
- `npx homey app validate`: passed publish level
- `npx homey app validate --level publish`: passed
- `git diff --check`: passed

Changed files:
- `.homeychangelog.json`
- `drivers/vacuum_xiaomi_vacuum_max/device.js`
- `test/vacuum-xiaomi-max-resilience.test.js`
- `test/vacuum-xiaomi-max-room-refresh.test.js`